### PR TITLE
Replace tabs with spaces

### DIFF
--- a/debugger/debugger.breakpoint.cpp
+++ b/debugger/debugger.breakpoint.cpp
@@ -2,30 +2,30 @@
 
 namespace Debugger
 {
-	DebugLoop::Breakpoint::Breakpoint(Address address) :
-		OnReached(this)
-	{
-		Addr = address;
-		OpCode = 0;
-		IsWritten = false;
-	}
-	DebugLoop::Breakpoint::Breakpoint() noexcept :
-		OnReached(this)
-	{}
-	DebugLoop::Breakpoint::~Breakpoint() = default;
+    DebugLoop::Breakpoint::Breakpoint(Address address) :
+        OnReached(this)
+    {
+        Addr = address;
+        OpCode = 0;
+        IsWritten = false;
+    }
+    DebugLoop::Breakpoint::Breakpoint() noexcept :
+        OnReached(this)
+    {}
+    DebugLoop::Breakpoint::~Breakpoint() = default;
 
-	DebugLoop::Breakpoint::Breakpoint(DebugLoop::Breakpoint&& other) noexcept :
-		OnReached(std::exchange(other.OnReached, { nullptr })),
-		Addr(std::exchange(other.Addr, nullptr)),
-		OpCode(std::exchange(other.OpCode, 0)),
-		IsWritten(std::exchange(other.IsWritten, false))
-	{}
-	DebugLoop::Breakpoint& DebugLoop::Breakpoint::operator=(DebugLoop::Breakpoint&& other) noexcept
-	{
-		OnReached = std::exchange(other.OnReached, { nullptr });
-		Addr = std::exchange(Addr, nullptr);
-		OpCode = std::exchange(OpCode, 0);
-		IsWritten = std::exchange(other.IsWritten, false);
-		return *this;
-	}
+    DebugLoop::Breakpoint::Breakpoint(DebugLoop::Breakpoint&& other) noexcept :
+        OnReached(std::exchange(other.OnReached, { nullptr })),
+        Addr(std::exchange(other.Addr, nullptr)),
+        OpCode(std::exchange(other.OpCode, 0)),
+        IsWritten(std::exchange(other.IsWritten, false))
+    {}
+    DebugLoop::Breakpoint& DebugLoop::Breakpoint::operator=(DebugLoop::Breakpoint&& other) noexcept
+    {
+        OnReached = std::exchange(other.OnReached, { nullptr });
+        Addr = std::exchange(Addr, nullptr);
+        OpCode = std::exchange(OpCode, 0);
+        IsWritten = std::exchange(other.IsWritten, false);
+        return *this;
+    }
 }

--- a/debugger/debugger.cpp
+++ b/debugger/debugger.cpp
@@ -1,115 +1,115 @@
-#include "debugger.hpp"
 #include <filesystem>
+#include "debugger.hpp"
 
 namespace Debugger
 {
-	ProcessHandle DebugLoop::InitProcess(string_view const& executablePath, string_view const& arguments)
-	{
-		SetEnvironmentVariable("_NO_DEBUG_HEAP", "1");
+    ProcessHandle DebugLoop::InitProcess(string_view const& executablePath, string_view const& arguments)
+    {
+        SetEnvironmentVariable("_NO_DEBUG_HEAP", "1");
 
-		if (CreateProcess(
-			executablePath.data(), const_cast<LPSTR>(arguments.data()),
-			nullptr, nullptr, false,
-			DEBUG_ONLY_THIS_PROCESS | CREATE_SUSPENDED,
-			nullptr, nullptr, &StartupInfo, &ProcessInfo) == FALSE)
-		{
-			throw process_creation_error();
-		}
+        if (CreateProcess(
+            executablePath.data(), const_cast<LPSTR>(arguments.data()),
+            nullptr, nullptr, false,
+            DEBUG_ONLY_THIS_PROCESS | CREATE_SUSPENDED,
+            nullptr, nullptr, &StartupInfo, &ProcessInfo) == FALSE)
+        {
+            throw process_creation_error();
+        }
 
-		return OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessInfo.dwProcessId);
-		//_dbgProcessHandle = ProcessHandle(OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessInfo.dwProcessId));	
-	}
-	DebugLoop::DebugLoop(string_view const& executablePath, string_view const& arguments, bool freeMemory) :
-		OnProcessCreated(this),
-		OnBreakpoint(this),
-		OnUnregisteredBreakpoint(this),
-		OnSingleStep(this),
-		OnAccessViolation(this),
-		OnDllLoaded(this),
-		OnDllUnloaded(this),
-		OnThreadAdded(this),
-		OnThreadRemoved(this),
-		ExecutablePath(executablePath)
-	{
-		SetEnvironmentVariable("_NO_DEBUG_HEAP", "1");
+        return OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessInfo.dwProcessId);
+        //_dbgProcessHandle = ProcessHandle(OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessInfo.dwProcessId));
+    }
+    DebugLoop::DebugLoop(string_view const& executablePath, string_view const& arguments, bool freeMemory) :
+        OnProcessCreated(this),
+        OnBreakpoint(this),
+        OnUnregisteredBreakpoint(this),
+        OnSingleStep(this),
+        OnAccessViolation(this),
+        OnDllLoaded(this),
+        OnDllUnloaded(this),
+        OnThreadAdded(this),
+        OnThreadRemoved(this),
+        ExecutablePath(executablePath)
+    {
+        SetEnvironmentVariable("_NO_DEBUG_HEAP", "1");
 
-		string exePath = executablePath.data();
-		string args = arguments.data();
+        string exePath = executablePath.data();
+        string args    = arguments.data();
 
-		if (CreateProcess(
-			executablePath.data(), 
-			const_cast<LPSTR>(arguments.data()),
-			nullptr, nullptr, false,
-			DEBUG_ONLY_THIS_PROCESS | CREATE_SUSPENDED,
-			nullptr, nullptr, &StartupInfo, &ProcessInfo) == FALSE)
-		{
-			throw process_creation_error();
-		}
+        if (CreateProcess(
+            executablePath.data(), 
+            const_cast<LPSTR>(arguments.data()),
+            nullptr, nullptr, false,
+            DEBUG_ONLY_THIS_PROCESS | CREATE_SUSPENDED,
+            nullptr, nullptr, &StartupInfo, &ProcessInfo) == FALSE)
+        {
+            throw process_creation_error();
+        }
 
-		_dbgProcessHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessInfo.dwProcessId);
-		Memory = ProcessMemory { _dbgProcessHandle, freeMemory };
-		ThreadMgr = ThreadManager { _dbgProcessHandle };
-		
-		MainThread = &ThreadMgr.FindOrEmplace(ProcessInfo.dwThreadId, ProcessInfo.hThread);
-	}
-	DebugLoop::~DebugLoop()
-	{
-		CloseHandle(_dbgProcessHandle);
-	}
+        _dbgProcessHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, ProcessInfo.dwProcessId);
+        Memory            = ProcessMemory { _dbgProcessHandle, freeMemory };
+        ThreadMgr         = ThreadManager { _dbgProcessHandle };
+        
+        MainThread        = &ThreadMgr.FindOrEmplace(ProcessInfo.dwThreadId, ProcessInfo.hThread);
+    }
+    DebugLoop::~DebugLoop()
+    {
+        CloseHandle(_dbgProcessHandle);
+    }
 
-	DllInfo& DebugLoop::Find(string_view const& dllBaseName)
-	{
-		for (auto& pair : Dlls)
-		{
-			std::filesystem::path dllPath = pair.second.FileName;
-			if(dllBaseName == dllPath.filename())
-				return pair.second;
-		}
-		throw dll_not_found_error { dllBaseName };
-	}
-	
-	void DebugLoop::SetBreakpoint(Address address)
-	{
-		Breakpoint& bp = Breakpoints[address];
-		Memory.Write(bp.Addr, &INT3, sizeof(BYTE));
-		bp.IsWritten = true;
-	}
-	void DebugLoop::SetBreakpoint(Breakpoint& bp)
-	{
-		Memory.Write(bp.Addr, &INT3, sizeof(BYTE));
-		bp.IsWritten = true;
-	}
-	void DebugLoop::RestoreBreakpoint(Address address)
-	{
-		Breakpoint& bp = Breakpoints[address];
-		Memory.Write(bp.Addr, &bp.OpCode, sizeof(BYTE));
-		bp.IsWritten = false;
-	}
-	void DebugLoop::RestoreOpcode(Breakpoint& bp)
-	{
-		Memory.Write(bp.Addr, &bp.OpCode, sizeof(BYTE));
-		bp.IsWritten = false;
-	}
-	DebugLoop::Breakpoint& DebugLoop::AddBreakpoint(Address address, bool write)
-	{
-		Breakpoint& bp = Breakpoints.emplace(address, Breakpoint { address }).first->second;
-		Memory.Read(bp.Addr, &bp.OpCode, sizeof(BYTE));
-		if(write)
-			SetBreakpoint(bp);
-		return bp;
-	}
-	bool DebugLoop::RemoveBreakpoint(Address address)
-	{
-		if(auto const it = Breakpoints.find(address); it != Breakpoints.end())
-		{
-			Breakpoint& bp = it->second;
-			if(bp.IsWritten)
-				RestoreOpcode(bp);
-			
-			Breakpoints.erase(it);
+    DllInfo& DebugLoop::Find(string_view const& dllBaseName)
+    {
+        for (auto& pair : Dlls)
+        {
+            std::filesystem::path dllPath = pair.second.FileName;
+            if(dllBaseName == dllPath.filename())
+                return pair.second;
+        }
+        throw dll_not_found_error { dllBaseName };
+    }
+    
+    void DebugLoop::SetBreakpoint(Address address)
+    {
+        Breakpoint& bp = Breakpoints[address];
+        Memory.Write(bp.Addr, &INT3, sizeof(BYTE));
+        bp.IsWritten = true;
+    }
+    void DebugLoop::SetBreakpoint(Breakpoint& bp)
+    {
+        Memory.Write(bp.Addr, &INT3, sizeof(BYTE));
+        bp.IsWritten = true;
+    }
+    void DebugLoop::RestoreBreakpoint(Address address)
+    {
+        Breakpoint& bp = Breakpoints[address];
+        Memory.Write(bp.Addr, &bp.OpCode, sizeof(BYTE));
+        bp.IsWritten = false;
+    }
+    void DebugLoop::RestoreOpcode(Breakpoint& bp)
+    {
+        Memory.Write(bp.Addr, &bp.OpCode, sizeof(BYTE));
+        bp.IsWritten = false;
+    }
+    DebugLoop::Breakpoint& DebugLoop::AddBreakpoint(Address address, bool write)
+    {
+        Breakpoint& bp = Breakpoints.emplace(address, Breakpoint { address }).first->second;
+        Memory.Read(bp.Addr, &bp.OpCode, sizeof(BYTE));
+        if(write)
+            SetBreakpoint(bp);
+        return bp;
+    }
+    bool DebugLoop::RemoveBreakpoint(Address address)
+    {
+        if(auto const it = Breakpoints.find(address); it != Breakpoints.end())
+        {
+            Breakpoint& bp = it->second;
+            if(bp.IsWritten)
+                RestoreOpcode(bp);
+            
+            Breakpoints.erase(it);
 
-			return true;
-		}
-		return false;
-	}
+            return true;
+        }
+        return false;
+    }
 }

--- a/debugger/debugger.handlers.cpp
+++ b/debugger/debugger.handlers.cpp
@@ -1,89 +1,89 @@
-#include "debugger.hpp"
 #include <macro.hpp>
+#include "debugger.hpp"
 
 namespace Debugger
 {
-	DWORD DebugLoop::HandleException(DEBUG_EVENT& dbgEvent)
-	{
-		auto const exceptCode = dbgEvent.u.Exception.ExceptionRecord.ExceptionCode;
-		auto const exceptAddress = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
-	
-		switch (exceptCode)
-		{
-		case(EXCEPTION_BREAKPOINT):
-			return HandleBreakpoint(dbgEvent);
-		case(EXCEPTION_SINGLE_STEP):
-			return HandleSingleStep(dbgEvent);
-		case(EXCEPTION_ACCESS_VIOLATION):
-			return HandleAccessViolation(dbgEvent);
-		default:
-			return DBG_CONTINUE;
-		}
-	}
+    DWORD DebugLoop::HandleException(DEBUG_EVENT& dbgEvent)
+    {
+        auto const exceptCode    = dbgEvent.u.Exception.ExceptionRecord.ExceptionCode;
+        auto const exceptAddress = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
+    
+        switch (exceptCode)
+        {
+        case(EXCEPTION_BREAKPOINT):
+            return HandleBreakpoint(dbgEvent);
+        case(EXCEPTION_SINGLE_STEP):
+            return HandleSingleStep(dbgEvent);
+        case(EXCEPTION_ACCESS_VIOLATION):
+            return HandleAccessViolation(dbgEvent);
+        default:
+            return DBG_CONTINUE;
+        }
+    }
 
-	DWORD DebugLoop::HandleBreakpoint(DEBUG_EVENT& dbgEvent)
-	{
-		auto const address = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
-		auto const threadId = dbgEvent.dwThreadId;
-		
-		Thread& thread = ThreadMgr[threadId];
-		thread.LastBreakpoint = address;
-		
-		if(auto const it = Breakpoints.find(address); it != Breakpoints.end())			
-		{
-			Breakpoint& bp = it->second;
-			OnBreakpoint(thread, bp);
-			bp.OnReached(*this, thread);
-			
-			RestoreOpcode(bp);
+    DWORD DebugLoop::HandleBreakpoint(DEBUG_EVENT& dbgEvent)
+    {
+        auto const address  = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
+        auto const threadId = dbgEvent.dwThreadId;
+        
+        Thread& thread        = ThreadMgr[threadId];
+        thread.LastBreakpoint = address;
+        
+        if(auto const it = Breakpoints.find(address); it != Breakpoints.end())
+        {
+            Breakpoint& bp = it->second;
+            OnBreakpoint(thread, bp);
+            bp.OnReached(*this, thread);
+            
+            RestoreOpcode(bp);
 
-			auto* pBp = &bp;
-			DefferedBreakpoints.emplace(threadId, pBp);
-			
-			thread.EnableSingleStep();
-		}
-		else
-			OnUnregisteredBreakpoint(
-				thread,
-				dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress);
+            auto* pBp = &bp;
+            DefferedBreakpoints.emplace(threadId, pBp);
+            
+            thread.EnableSingleStep();
+        }
+        else
+            OnUnregisteredBreakpoint(
+                thread,
+                dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress);
 
-		return DBG_CONTINUE;
-	}
+        return DBG_CONTINUE;
+    }
 
-	DWORD DebugLoop::HandleSingleStep(DEBUG_EVENT& dbgEvent)
-	{
-		auto const address = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
-		auto const threadId = dbgEvent.dwThreadId;
-		
-		Thread& thread = ThreadMgr[threadId];
-		if(auto const it = DefferedBreakpoints.find(threadId); it != DefferedBreakpoints.end())
-		{
-			Breakpoint& bp = reference_cast(it->second);
-			if(bp.Addr == thread.LastBreakpoint)
-			{
-				SetBreakpoint(bp);
-				thread.DisableSingleStep();
+    DWORD DebugLoop::HandleSingleStep(DEBUG_EVENT& dbgEvent)
+    {
+        auto const address = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
+        auto const threadId = dbgEvent.dwThreadId;
+        
+        Thread& thread = ThreadMgr[threadId];
+        if(auto const it = DefferedBreakpoints.find(threadId); it != DefferedBreakpoints.end())
+        {
+            Breakpoint& bp = reference_cast(it->second);
+            if(bp.Addr == thread.LastBreakpoint)
+            {
+                SetBreakpoint(bp);
+                thread.DisableSingleStep();
 
-				DefferedBreakpoints.erase(it);
-				
-				return DBG_CONTINUE;
-			}				
-		}
+                DefferedBreakpoints.erase(it);
+                
+                return DBG_CONTINUE;
+            }                
+        }
 
-		OnSingleStep(thread, address);
-		return DBG_CONTINUE;
-	}
-	
-	DWORD DebugLoop::HandleAccessViolation(DEBUG_EVENT& dbgEvent)
-	{
-		auto const exceptCode = dbgEvent.u.Exception.ExceptionRecord.ExceptionCode;
-		auto const exceptAddress = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
-		auto const threadId = dbgEvent.dwThreadId;
-		
-		Thread& thread = ThreadMgr[threadId];
-		
-		OnAccessViolation(thread, exceptAddress);
-		
-		return DBG_EXCEPTION_NOT_HANDLED;
-	}
+        OnSingleStep(thread, address);
+        return DBG_CONTINUE;
+    }
+    
+    DWORD DebugLoop::HandleAccessViolation(DEBUG_EVENT& dbgEvent)
+    {
+        auto const exceptCode = dbgEvent.u.Exception.ExceptionRecord.ExceptionCode;
+        auto const exceptAddress = dbgEvent.u.Exception.ExceptionRecord.ExceptionAddress;
+        auto const threadId = dbgEvent.dwThreadId;
+        
+        Thread& thread = ThreadMgr[threadId];
+        
+        OnAccessViolation(thread, exceptAddress);
+        
+        return DBG_EXCEPTION_NOT_HANDLED;
+    }
 }

--- a/debugger/debugger.hpp
+++ b/debugger/debugger.hpp
@@ -1,136 +1,136 @@
 ﻿#ifndef DEBUGGER_DEBUGGER_HPP
 #define DEBUGGER_DEBUGGER_HPP
 
-#include "typedefs.hpp"
-
-#include <events.hpp>
 #include <map>
 #include <string>
 #include <string_view>
 
+#include <events.hpp>
+
+#include "typedefs.hpp"
 #include "dll_info.hpp"
 #include "thread_manager.hpp"
 #include "process_memory.hpp"
 
 namespace Debugger
 {
-	using namespace Utilities;
-	using std::map;
-	using std::string;
-	using std::string_view;
+    using namespace Utilities;
+    using std::map;
+    using std::string;
+    using std::string_view;
 
-	/*!
-	* @author multfinite
-	* @brief This class provides generic way to implement debuf loop.
-	* @brief First, it handles basic debug loop events: DLL load\\unload, Thread create\\exit.
-	* @brief Second, it allow to set breakpoints and handles event when (any) breakpoint reached. Also able to use single step mode.
-	* @brief Thrid, it will notice when access violation occurs.
-	*/
-	class DebugLoop
-	{		
-	public:
-		struct Breakpoint;
+    /*!
+    * @author multfinite
+    * @brief This class provides generic way to implement debuf loop.
+    * @brief First, it handles basic debug loop events: DLL load\\unload, Thread create\\exit.
+    * @brief Second, it allow to set breakpoints and handles event when (any) breakpoint reached. Also able to use single step mode.
+    * @brief Thrid, it will notice when access violation occurs.
+    */
+    class DebugLoop
+    {        
+    public:
+        struct Breakpoint;
 
-		using ExceptionCode						= DWORD;
-		using ThreadCreationFlags				= DWORD;
-		using ThreadProcessParameter		= LPVOID;
+        using ExceptionCode          = DWORD;
+        using ThreadCreationFlags    = DWORD;
+        using ThreadProcessParameter = LPVOID;
 
-		using BreakpointEvent					= ObjectEvent<DebugLoop, Thread&, Breakpoint&>;
-		using AccessViolationEvent				= ObjectEvent<DebugLoop, Thread&, Address>;
-		using ThreadEvent							= ObjectEvent<DebugLoop, Thread&, Address>;
-		using DllEvent								= ObjectEvent<DebugLoop, DllInfo&>;
-		using DebuggerEvent						= ObjectEvent<DebugLoop>;
-		using ThreadActionEvent					= ObjectEvent<DebugLoop, Thread&>; 
+        using BreakpointEvent        = ObjectEvent<DebugLoop, Thread&, Breakpoint&>;
+        using AccessViolationEvent   = ObjectEvent<DebugLoop, Thread&, Address>;
+        using ThreadEvent            = ObjectEvent<DebugLoop, Thread&, Address>;
+        using DllEvent               = ObjectEvent<DebugLoop, DllInfo&>;
+        using DebuggerEvent          = ObjectEvent<DebugLoop>;
+        using ThreadActionEvent      = ObjectEvent<DebugLoop, Thread&>; 
 
-		using BreakpointMap						= map<Address, Breakpoint>;
+        using BreakpointMap          = map<Address, Breakpoint>;
 
-		BYTE INT3 = 0xCC;
-	public:
-		/*!
-		* @author multfinite
-		* @brief Just a container for breakpoint.
-		* @brief OnReached event can be used to be noticed when breakpoint reached.
-		*/
-		struct Breakpoint final
-		{
-			using Event	= ObjectEvent<Breakpoint, DebugLoop&, Thread&>;
+        BYTE  INT3                   = 0xCC;
+    public:
+        /*!
+        * @author multfinite
+        * @brief Just a container for breakpoint.
+        * @brief OnReached event can be used to be noticed when breakpoint reached.
+        */
+        struct Breakpoint final
+        {
+            using Event = ObjectEvent<Breakpoint, DebugLoop&, Thread&>;
 
-			Event			OnReached;
-			
-			Address			Addr;
-			BYTE				OpCode;
-			bool				IsWritten;
+            Event   OnReached;
+            
+            Address Addr;
+            BYTE    OpCode;
+            bool    IsWritten;
 
-			Breakpoint() noexcept;
-			Breakpoint(Address address);
-			~Breakpoint();
-			
-			Breakpoint(Breakpoint&& other) noexcept;
-			Breakpoint& operator=(Breakpoint&& other) noexcept;
+            Breakpoint() noexcept;
+            Breakpoint(Address address);
+            ~Breakpoint();
+            
+            Breakpoint(Breakpoint&& other) noexcept;
+            Breakpoint& operator=(Breakpoint&& other) noexcept;
 
-			Breakpoint(Breakpoint& other) = delete;
-			Breakpoint& operator=(Breakpoint const& other) = delete;
-		};
+            Breakpoint(Breakpoint& other) = delete;
+            Breakpoint& operator=(Breakpoint const& other) = delete;
+        };
 
-		struct process_creation_error : std::exception {	};
-		struct dll_not_found_error : std::exception
-		{
-			string const BaseName;
-			dll_not_found_error(string_view const& baseName) :
-				BaseName(baseName)
-			{ }
-		};
+        struct process_creation_error : std::exception {    };
+        struct dll_not_found_error : std::exception
+        {
+            string const BaseName;
+            dll_not_found_error(string_view const& baseName) :
+                BaseName(baseName)
+            { }
+        };
 
-		DebuggerEvent								OnProcessCreated;
-		BreakpointEvent								OnBreakpoint;
-		ThreadEvent									OnUnregisteredBreakpoint;
-		ThreadEvent									OnSingleStep;
-		AccessViolationEvent						OnAccessViolation;
+        DebuggerEvent              OnProcessCreated;
+        BreakpointEvent            OnBreakpoint;
+        ThreadEvent                OnUnregisteredBreakpoint;
+        ThreadEvent                OnSingleStep;
+        AccessViolationEvent       OnAccessViolation;
 
-		DllEvent											OnDllLoaded;
-		DllEvent											OnDllUnloaded;
+        DllEvent                   OnDllLoaded;
+        DllEvent                   OnDllUnloaded;
 
-		ThreadActionEvent							OnThreadAdded;
-		ThreadActionEvent							OnThreadRemoved;
+        ThreadActionEvent          OnThreadAdded;
+        ThreadActionEvent          OnThreadRemoved;
 
-		STARTUPINFO								StartupInfo{};
-		CREATE_PROCESS_DEBUG_INFO		ProcessDebugInfo{};
-		PROCESS_INFORMATION				ProcessInfo{};
-		//MODULEINFO								ProcessModuleInfo;
-				
-		BreakpointMap								Breakpoints;		
-		DllMap											Dlls;
+        STARTUPINFO                StartupInfo{};
+        CREATE_PROCESS_DEBUG_INFO  ProcessDebugInfo{};
+        PROCESS_INFORMATION        ProcessInfo{};
+        //MODULEINFO               ProcessModuleInfo;
+                
+        BreakpointMap              Breakpoints;        
+        DllMap                     Dlls;
 
-		Thread*											MainThread;
-		map<ThreadId, Breakpoint*>			DefferedBreakpoints;
-	private:
-		ProcessHandle								_dbgProcessHandle;
-	public:
-		ProcessMemory								Memory;
-		ThreadManager								ThreadMgr;
+        Thread*                    MainThread;
+        map<ThreadId, Breakpoint*> DefferedBreakpoints;
+    private:
+        ProcessHandle              _dbgProcessHandle;
+    public:
+        ProcessMemory              Memory;
+        ThreadManager              ThreadMgr;
 
-		string	const									ExecutablePath;
-	private:
-		ProcessHandle InitProcess(string_view const& executablePath, string_view const& arguments);
-	public:
-		DebugLoop(string_view const& executablePath, string_view const& arguments, bool freeMemory = true);
-		~DebugLoop();
-		DllInfo& Find(string_view const& dllBaseName);
-		ProcessHandle Process() const { return _dbgProcessHandle; }
-		
-		void SetBreakpoint(Address address);
-		void SetBreakpoint(Breakpoint& bp);
-		void RestoreBreakpoint(Address address);
-		void RestoreOpcode(Breakpoint& bp);
-		Breakpoint& AddBreakpoint(Address address, bool write = true);
-		bool RemoveBreakpoint(Address address);
-		
-		void Run();
-	private:
-		DWORD HandleException(DEBUG_EVENT& dbgEvent);
-		DWORD HandleBreakpoint(DEBUG_EVENT& dbgEvent);
-		DWORD HandleSingleStep(DEBUG_EVENT& dbgEvent);		
-		DWORD HandleAccessViolation(DEBUG_EVENT& dbgEvent);
-	};
+        string    const                                    ExecutablePath;
+    private:
+        ProcessHandle InitProcess(string_view const& executablePath, string_view const& arguments);
+    public:
+        DebugLoop(string_view const& executablePath, string_view const& arguments, bool freeMemory = true);
+        ~DebugLoop();
+        DllInfo& Find(string_view const& dllBaseName);
+        ProcessHandle Process() const { return _dbgProcessHandle; }
+        
+        void SetBreakpoint(Address address);
+        void SetBreakpoint(Breakpoint& bp);
+        void RestoreBreakpoint(Address address);
+        void RestoreOpcode(Breakpoint& bp);
+        Breakpoint& AddBreakpoint(Address address, bool write = true);
+        bool RemoveBreakpoint(Address address);
+        
+        void Run();
+    private:
+        DWORD HandleException(DEBUG_EVENT& dbgEvent);
+        DWORD HandleBreakpoint(DEBUG_EVENT& dbgEvent);
+        DWORD HandleSingleStep(DEBUG_EVENT& dbgEvent);        
+        DWORD HandleAccessViolation(DEBUG_EVENT& dbgEvent);
+    };
 }
 #endif //DEBUGGER_DEBUGGER_HPP

--- a/debugger/debugger.loop.cpp
+++ b/debugger/debugger.loop.cpp
@@ -2,94 +2,94 @@
 
 namespace Debugger
 {
-	void DebugLoop::Run()
-	{
-		//Log::WriteLine(
-			//__FUNCTION__ ": Running process to debug. cmd = \"%s %.*s\"",
-			//exe.c_str(), printable(arguments));
-		//DebugProcess(arguments);
+    void DebugLoop::Run()
+    {
+        //Log::WriteLine(
+            //__FUNCTION__ ": Running process to debug. cmd = \"%s %.*s\"",
+            //exe.c_str(), printable(arguments));
+        //DebugProcess(arguments);
 
-		DEBUG_EVENT dbgEvent;
-		
-		MainThread->Resume();
+        DEBUG_EVENT dbgEvent;
+        
+        MainThread->Resume();
 
-		//Log::WriteLine(__FUNCTION__ ": Entering debug loop...");
+        //Log::WriteLine(__FUNCTION__ ": Entering debug loop...");
 
-		auto exit_code = static_cast<DWORD>(-1);
+        auto exit_code = static_cast<DWORD>(-1);
 
-		for (;;)
-		{
-			WaitForDebugEvent(&dbgEvent, INFINITE);
+        for (;;)
+        {
+            WaitForDebugEvent(&dbgEvent, INFINITE);
 
-			DWORD continueStatus = DBG_CONTINUE;
+            DWORD continueStatus = DBG_CONTINUE;
 
-			switch (dbgEvent.dwDebugEventCode)
-			{
-			case CREATE_PROCESS_DEBUG_EVENT:
-				{
-					ProcessInfo.hProcess = dbgEvent.u.CreateProcessInfo.hProcess;
-					ProcessInfo.dwThreadId = dbgEvent.dwProcessId;
-					ProcessInfo.hThread = dbgEvent.u.CreateProcessInfo.hThread;
-					ProcessInfo.dwThreadId = dbgEvent.dwThreadId;
+            switch (dbgEvent.dwDebugEventCode)
+            {
+            case CREATE_PROCESS_DEBUG_EVENT:
+                {
+                    ProcessInfo.hProcess = dbgEvent.u.CreateProcessInfo.hProcess;
+                    ProcessInfo.dwThreadId = dbgEvent.dwProcessId;
+                    ProcessInfo.hThread = dbgEvent.u.CreateProcessInfo.hThread;
+                    ProcessInfo.dwThreadId = dbgEvent.dwThreadId;
 
-					ProcessDebugInfo = dbgEvent.u.CreateProcessInfo;
+                    ProcessDebugInfo = dbgEvent.u.CreateProcessInfo;
 
-					OnProcessCreated();
-					
-					CloseHandle(dbgEvent.u.CreateProcessInfo.hFile);
-				}	break;
-			case CREATE_THREAD_DEBUG_EVENT:
-				{
-					Thread& thread = ThreadMgr.FindOrEmplace(
-						dbgEvent.dwThreadId, 
-						dbgEvent.u.CreateThread.hThread);				
-					OnThreadAdded(thread); 
-				}	break;
-			case EXIT_THREAD_DEBUG_EVENT:
-				{
-					Thread& thread = ThreadMgr[dbgEvent.dwThreadId];
-					OnThreadRemoved(thread);
-					ThreadMgr.Remove(thread);
-				}	break;
-			case EXCEPTION_DEBUG_EVENT:
-				{
-					continueStatus = HandleException(dbgEvent);
-				}	break;
-			case LOAD_DLL_DEBUG_EVENT:
-				{
-					auto const		base	= dbgEvent.u.LoadDll.lpBaseOfDll;
-					auto				p		= Dlls.emplace(base, dbgEvent.u.LoadDll);
-					p.first->second.LoadVersion();
-					OnDllLoaded(p.first->second);
-				}	break;
-			case UNLOAD_DLL_DEBUG_EVENT:
-				{
-					auto const base = dbgEvent.u.UnloadDll.lpBaseOfDll;
-					DllInfo& dll = Dlls[base];
-					dll.Unloaded = true;
-					OnDllUnloaded(dll);
-				}	break;
-			case OUTPUT_DEBUG_STRING_EVENT:
-				{ } break;
-			}
+                    OnProcessCreated();
+                    
+                    CloseHandle(dbgEvent.u.CreateProcessInfo.hFile);
+                }    break;
+            case CREATE_THREAD_DEBUG_EVENT:
+                {
+                    Thread& thread = ThreadMgr.FindOrEmplace(
+                        dbgEvent.dwThreadId, 
+                        dbgEvent.u.CreateThread.hThread);                
+                    OnThreadAdded(thread); 
+                }    break;
+            case EXIT_THREAD_DEBUG_EVENT:
+                {
+                    Thread& thread = ThreadMgr[dbgEvent.dwThreadId];
+                    OnThreadRemoved(thread);
+                    ThreadMgr.Remove(thread);
+                }    break;
+            case EXCEPTION_DEBUG_EVENT:
+                {
+                    continueStatus = HandleException(dbgEvent);
+                }    break;
+            case LOAD_DLL_DEBUG_EVENT:
+                {
+                    auto const base = dbgEvent.u.LoadDll.lpBaseOfDll;
+                    auto       p    = Dlls.emplace(base, dbgEvent.u.LoadDll);
+                    p.first->second.LoadVersion();
+                    OnDllLoaded(p.first->second);
+                }    break;
+            case UNLOAD_DLL_DEBUG_EVENT:
+                {
+                    auto const base = dbgEvent.u.UnloadDll.lpBaseOfDll;
+                    DllInfo& dll = Dlls[base];
+                    dll.Unloaded = true;
+                    OnDllUnloaded(dll);
+                }    break;
+            case OUTPUT_DEBUG_STRING_EVENT:
+                { } break;
+            }
 
-			if (dbgEvent.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
-			{
-				exit_code = dbgEvent.u.ExitProcess.dwExitCode;
-				break;
-			}
-			else if (dbgEvent.dwDebugEventCode == RIP_EVENT)
-			{
-				break;
-			}
+            if (dbgEvent.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT)
+            {
+                exit_code = dbgEvent.u.ExitProcess.dwExitCode;
+                break;
+            }
+            else if (dbgEvent.dwDebugEventCode == RIP_EVENT)
+            {
+                break;
+            }
 
-			ContinueDebugEvent(dbgEvent.dwProcessId, dbgEvent.dwThreadId, continueStatus);
-		}
+            ContinueDebugEvent(dbgEvent.dwProcessId, dbgEvent.dwThreadId, continueStatus);
+        }
 
-		CloseHandle(ProcessInfo.hProcess);
+        CloseHandle(ProcessInfo.hProcess);
 
-		//Log::WriteLine(
-			//__FUNCTION__ ": Done with exit code %X (%u).", exit_code, exit_code);
-		//Log::WriteLine();
-	}	
+        //Log::WriteLine(
+            //__FUNCTION__ ": Done with exit code %X (%u).", exit_code, exit_code);
+        //Log::WriteLine();
+    }    
 }

--- a/debugger/dll_info.hpp
+++ b/debugger/dll_info.hpp
@@ -15,46 +15,46 @@
 */
 struct DllInfo
 {
-	HMODULE								Handle					{ nullptr };
-	LPVOID									Base						{ nullptr };
-	DWORD									FileSize					{ 0 };
-	std::string								FileName;
-	DWORD									ImageSize				{ 0 };
-	bool										Unloaded				{ false };
-	PECOFF::PortableExecutable	PE;
-	unsigned int							Checksum				{ 0 };
-	Utilities::FileVersionInformation	FVI;
+    HMODULE                           Handle    { nullptr };
+    LPVOID                            Base      { nullptr };
+    DWORD                             FileSize  { 0 };
+    std::string                       FileName;
+    DWORD                             ImageSize { 0 };
+    bool                              Unloaded  { false };
+    PECOFF::PortableExecutable        PE;
+    unsigned int                      Checksum  { 0 };
+    Utilities::FileVersionInformation FVI;
 
 public:
-	DllInfo() = default;
-	DllInfo(LOAD_DLL_DEBUG_INFO& info) :
-		FileName(Utilities::GetFileNameFromHandle(info.hFile)),
-		PE(Utilities::file_open_binary(FileName)),
-		ImageSize(PE.PEHeader.OptionalHeader.SizeOfImage),
-		Base(info.lpBaseOfDll),
-		FileSize(GetFileSize(info.hFile, nullptr)),
-		Checksum(Utilities::CRC32::compute_stream(Utilities::file_open_binary(FileName)))
-	{
-		GetModuleHandleEx(
-			GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-			(LPCTSTR)Base,
-			&Handle
-		);
-	}
-	~DllInfo() = default;
-	bool OwnsAddress(Address address) const { return (address >= Base) && (address < reinterpret_cast<BYTE*>(Base) + ImageSize); };
+    DllInfo() = default;
+    DllInfo(LOAD_DLL_DEBUG_INFO& info) :
+        FileName(Utilities::GetFileNameFromHandle(info.hFile)),
+        PE(Utilities::file_open_binary(FileName)),
+        ImageSize(PE.PEHeader.OptionalHeader.SizeOfImage),
+        Base(info.lpBaseOfDll),
+        FileSize(GetFileSize(info.hFile, nullptr)),
+        Checksum(Utilities::CRC32::compute_stream(Utilities::file_open_binary(FileName)))
+    {
+        GetModuleHandleEx(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            (LPCTSTR)Base,
+            &Handle
+        );
+    }
+    ~DllInfo() = default;
+    bool OwnsAddress(Address address) const { return (address >= Base) && (address < reinterpret_cast<BYTE*>(Base) + ImageSize); };
 
-	void LoadVersion()
-	{
-		try
-		{
-			FVI.Load(FileName);
-		}
-		catch(...) {}
-	}
+    void LoadVersion()
+    {
+        try
+        {
+            FVI.Load(FileName);
+        }
+        catch(...) {}
+    }
 };
 
-using DllBase		= LPVOID;
-using DllMap		= std::map<DllBase, DllInfo>;
+using DllBase        = LPVOID;
+using DllMap        = std::map<DllBase, DllInfo>;
 
 #endif //DEBUGGER_DLL_INFO_HPP

--- a/debugger/process_memory.hpp
+++ b/debugger/process_memory.hpp
@@ -2,7 +2,6 @@
 #define DEBUGGER_PROCESS_MEMORY_HPP
 
 #include <list>
-
 #include "virtual_memory_handle.hpp"
 
 /*!
@@ -16,72 +15,72 @@
 class ProcessMemory final
 {
 private:
-	HANDLE _process { nullptr };
-	bool _freeMemory = true;
-	
+    HANDLE _process { nullptr };
+    bool _freeMemory = true;
+    
 public:
-	std::list<VirtualMemoryHandle> MemoryHandles;
-	
-	ProcessMemory() noexcept = default;
-	ProcessMemory(HANDLE process, bool freeMemory = true) : _process(process), _freeMemory(freeMemory) { }
-	~ProcessMemory() = default;
+    std::list<VirtualMemoryHandle> MemoryHandles;
+    
+    ProcessMemory() noexcept = default;
+    ProcessMemory(HANDLE process, bool freeMemory = true) : _process(process), _freeMemory(freeMemory) { }
+    ~ProcessMemory() = default;
 
-	ProcessMemory(ProcessMemory& other) = delete;
-	ProcessMemory& operator=(ProcessMemory& other) = delete;
-	
-	ProcessMemory(ProcessMemory&& other) noexcept :
-		_process(std::exchange(other._process, nullptr)),
-		MemoryHandles(std::exchange(other.MemoryHandles, {})) { }
-	ProcessMemory& operator=(ProcessMemory&& other) noexcept
-	{
-		_process = std::exchange(other._process, nullptr);
-		MemoryHandles = std::exchange(other.MemoryHandles, {});
-		return  *this;
-	}
+    ProcessMemory(ProcessMemory& other) = delete;
+    ProcessMemory& operator=(ProcessMemory& other) = delete;
+    
+    ProcessMemory(ProcessMemory&& other) noexcept :
+        _process(std::exchange(other._process, nullptr)),
+        MemoryHandles(std::exchange(other.MemoryHandles, {})) { }
+    ProcessMemory& operator=(ProcessMemory&& other) noexcept
+    {
+        _process = std::exchange(other._process, nullptr);
+        MemoryHandles = std::exchange(other.MemoryHandles, {});
+        return  *this;
+    }
 
-	bool Read(void const* address, void* buffer, DWORD size) { return (ReadProcessMemory(_process, address, buffer, size, nullptr) != FALSE); }
-	bool ReadSingleByte(Address address, BYTE* returnValue)
-	{
-		SIZE_T sz = 0;
-		bool const result = ReadProcessMemory(_process, address, returnValue, sizeof(BYTE), &sz);
-		return result;
-	}
-	bool Write(void* address, void const* buffer, DWORD size) { return (WriteProcessMemory(_process, address, buffer, size, nullptr) != FALSE); }
-	
-	VirtualMemoryHandle& Allocate(size_t size)
-	{
-		return MemoryHandles.emplace_back(_process, size, _freeMemory);
-	}
-	VirtualMemoryHandle& Allocate(BYTE* pData, size_t size)
-	{
-		auto& vmh = MemoryHandles.emplace_back(_process, size, _freeMemory);
-		vmh.Write(pData, size, 0);
-		return vmh;
-	}
-	template<typename TInput>
-	VirtualMemoryHandle& Allocate(TInput& val)
-	{
-		size_t const size = sizeof(TInput);
-		auto& vmh = MemoryHandles.emplace_back(_process, size, _freeMemory);
-		vmh.Write(&val, size, 0);
-		return vmh;
-	}
-	
-	bool Free(VirtualMemoryHandle& handle)
-	{
-		std::list<VirtualMemoryHandle>::iterator iterator = std::find(MemoryHandles.begin(), MemoryHandles.end(), handle);
-		const bool contains = iterator != MemoryHandles.end();
-		if (contains)			
-			MemoryHandles.erase(iterator);			
-		return contains;
-	}	
+    bool Read(void const* address, void* buffer, DWORD size) { return (ReadProcessMemory(_process, address, buffer, size, nullptr) != FALSE); }
+    bool ReadSingleByte(Address address, BYTE* returnValue)
+    {
+        SIZE_T sz = 0;
+        bool const result = ReadProcessMemory(_process, address, returnValue, sizeof(BYTE), &sz);
+        return result;
+    }
+    bool Write(void* address, void const* buffer, DWORD size) { return (WriteProcessMemory(_process, address, buffer, size, nullptr) != FALSE); }
+    
+    VirtualMemoryHandle& Allocate(size_t size)
+    {
+        return MemoryHandles.emplace_back(_process, size, _freeMemory);
+    }
+    VirtualMemoryHandle& Allocate(BYTE* pData, size_t size)
+    {
+        auto& vmh = MemoryHandles.emplace_back(_process, size, _freeMemory);
+        vmh.Write(pData, size, 0);
+        return vmh;
+    }
+    template<typename TInput>
+    VirtualMemoryHandle& Allocate(TInput& val)
+    {
+        size_t const size = sizeof(TInput);
+        auto& vmh = MemoryHandles.emplace_back(_process, size, _freeMemory);
+        vmh.Write(&val, size, 0);
+        return vmh;
+    }
+    
+    bool Free(VirtualMemoryHandle& handle)
+    {
+        std::list<VirtualMemoryHandle>::iterator iterator = std::find(MemoryHandles.begin(), MemoryHandles.end(), handle);
+        const bool contains = iterator != MemoryHandles.end();
+        if (contains)            
+            MemoryHandles.erase(iterator);
+        return contains;
+    }    
 
-	bool IsVirtualAddress(Address address) const noexcept
-	{
-		for (VirtualMemoryHandle const& mh : MemoryHandles)			
-			if (mh.IsOwned(address))
-				return true;			
-		return false;
-	}
+    bool IsVirtualAddress(Address address) const noexcept
+    {
+        for (VirtualMemoryHandle const& mh : MemoryHandles)
+            if (mh.IsOwned(address))
+                return true;
+        return false;
+    }
 };
 #endif //DEBUGGER_PROCESS_MEMORY_HPP

--- a/debugger/thread.hpp
+++ b/debugger/thread.hpp
@@ -14,100 +14,100 @@
 class Thread
 {
 public:
-	ThreadId				Id									{ 0 };
-	ThreadHandle			Handle							{ nullptr };
-	ProcessId				OwnerId						{ 0 };
-	Address					LastBreakpoint				{ nullptr };
-	CONTEXT				Context							{ };
-	
-	Thread(Thread& other)								= delete;
-	Thread& operator=(Thread const& other)		= delete;
+    ThreadId     Id             { 0 };
+    ThreadHandle Handle         { nullptr };
+    ProcessId    OwnerId        { 0 };
+    Address      LastBreakpoint { nullptr };
+    CONTEXT      Context        { };
+    
+    Thread(Thread& other)                  = delete;
+    Thread& operator=(Thread const& other) = delete;
 
-	~Thread()
-	{
-		ProcessId const currentId = GetCurrentProcessId();
-		if (Handle && currentId == OwnerId)
-			CloseHandle(Handle);
-	}
-	Thread() noexcept;
-	Thread(ThreadHandle hThread, ThreadId id, ProcessId ownerId)
-		: Handle(hThread), Id(id), OwnerId(ownerId) { }
-	Thread(ThreadHandle hThread)
-		: Handle{ hThread }, Id{ GetThreadId(hThread) }, OwnerId(GetProcessIdOfThread(hThread)) { }
-	Thread(Thread&& other) noexcept :
-		OwnerId(std::exchange(other.OwnerId, 0)),
-		Handle(std::exchange(other.Handle, nullptr)),
-		Id(std::exchange(other.Id, 0)),
-		LastBreakpoint(std::exchange(other.LastBreakpoint, nullptr)),
-		Context(std::exchange(other.Context, {})) {}
-	Thread& operator=(Thread&& other) noexcept
-	{
-		OwnerId = std::exchange(other.OwnerId, 0);
-		Handle = std::exchange(other.Handle, nullptr);
-		Id = std::exchange(other.Id, 0);
-		LastBreakpoint = std::exchange(other.LastBreakpoint, nullptr);
-		Context = std::exchange(other.Context, {});
-		return *this;
-	}
+    ~Thread()
+    {
+        ProcessId const currentId = GetCurrentProcessId();
+        if (Handle && currentId == OwnerId)
+            CloseHandle(Handle);
+    }
+    Thread() noexcept;
+    Thread(ThreadHandle hThread, ThreadId id, ProcessId ownerId)
+        : Handle(hThread), Id(id), OwnerId(ownerId) { }
+    Thread(ThreadHandle hThread)
+        : Handle{ hThread }, Id{ GetThreadId(hThread) }, OwnerId(GetProcessIdOfThread(hThread)) { }
+    Thread(Thread&& other) noexcept :
+        OwnerId(std::exchange(other.OwnerId, 0)),
+        Handle(std::exchange(other.Handle, nullptr)),
+        Id(std::exchange(other.Id, 0)),
+        LastBreakpoint(std::exchange(other.LastBreakpoint, nullptr)),
+        Context(std::exchange(other.Context, {})) {}
+    Thread& operator=(Thread&& other) noexcept
+    {
+        OwnerId = std::exchange(other.OwnerId, 0);
+        Handle = std::exchange(other.Handle, nullptr);
+        Id = std::exchange(other.Id, 0);
+        LastBreakpoint = std::exchange(other.LastBreakpoint, nullptr);
+        Context = std::exchange(other.Context, {});
+        return *this;
+    }
 
-	Thread(
-		ProcessHandle process,
-		ThreadStartRoutine routineFunc,
-		ThreadProcessParameter parameter				= nullptr,
-		ThreadCreationFlags creationFlags				= CREATE_SUSPENDED
-	)		: OwnerId(GetProcessId(process))
-	{
-		Handle = CreateRemoteThread(
-			process, nullptr, 0,
-			routineFunc, parameter,
-			creationFlags,
-			&Id);
-	}
-	Thread(
-		ThreadStartRoutine routineFunc,
-		ThreadProcessParameter parameter				= nullptr,
-		ThreadCreationFlags creationFlags				= CREATE_SUSPENDED
-	)		: OwnerId(GetCurrentProcessId())
-	{
-		Handle = CreateThread(
-			nullptr, 0,
-			routineFunc, parameter,
-			creationFlags,
-			&Id);
-	}
+    Thread(
+        ProcessHandle process,
+        ThreadStartRoutine routineFunc,
+        ThreadProcessParameter parameter  = nullptr,
+        ThreadCreationFlags creationFlags = CREATE_SUSPENDED
+    )        : OwnerId(GetProcessId(process))
+    {
+        Handle = CreateRemoteThread(
+            process, nullptr, 0,
+            routineFunc, parameter,
+            creationFlags,
+            &Id);
+    }
+    Thread(
+        ThreadStartRoutine routineFunc,
+        ThreadProcessParameter parameter  = nullptr,
+        ThreadCreationFlags creationFlags = CREATE_SUSPENDED
+    )        : OwnerId(GetCurrentProcessId())
+    {
+        Handle = CreateThread(
+            nullptr, 0,
+            routineFunc, parameter,
+            creationFlags,
+            &Id);
+    }
 
-	void			EnableSingleStep()
-		{
-			Context.ContextFlags = CONTEXT_CONTROL;
-			auto r = GetThreadContext(Handle, &Context);
-			Context.EFlags |= 0x100;
-			SetThreadContext(Handle, &Context);
-		}
-	void			DisableSingleStep()
-		{
-			Context.ContextFlags = CONTEXT_FULL;
-			auto r = GetThreadContext(Handle, &Context);
-			Context.EFlags &= 0x100;
-			r = SetThreadContext(Handle, &Context);
-		}
-	CONTEXT&	GetContext(ContextFlags flags)
-		{
-			Context.ContextFlags = flags;
-			auto r = GetThreadContext(Handle, &Context);
-			return Context;
-		}
-	BOOL		SetContext(ContextFlags flags)
-		{
-			Context.ContextFlags = flags;
-			return SetThreadContext(Handle, &Context);
-		}
-	BOOL		SetContext(CONTEXT& context)
-		{
-			Context = context;
-			return SetThreadContext(Handle, &Context);
-		}
-	DWORD 	Resume()								{	return ResumeThread(Handle); 	}
-	DWORD		Suspend()								{	return SuspendThread(Handle);	}
-	BOOL		Terminate(DWORD exitCode)	{	return TerminateThread(Handle, exitCode); }
+    void EnableSingleStep()
+        {
+            Context.ContextFlags = CONTEXT_CONTROL;
+            auto r = GetThreadContext(Handle, &Context);
+            Context.EFlags |= 0x100;
+            SetThreadContext(Handle, &Context);
+        }
+    void DisableSingleStep()
+        {
+            Context.ContextFlags = CONTEXT_FULL;
+            auto r = GetThreadContext(Handle, &Context);
+            Context.EFlags &= 0x100;
+            r = SetThreadContext(Handle, &Context);
+        }
+    CONTEXT& GetContext(ContextFlags flags)
+        {
+            Context.ContextFlags = flags;
+            auto r = GetThreadContext(Handle, &Context);
+            return Context;
+        }
+    BOOL SetContext(ContextFlags flags)
+        {
+            Context.ContextFlags = flags;
+            return SetThreadContext(Handle, &Context);
+        }
+    BOOL SetContext(CONTEXT& context)
+        {
+            Context = context;
+            return SetThreadContext(Handle, &Context);
+        }
+    DWORD Resume()                  { return ResumeThread(Handle); }
+    DWORD Suspend()                 { return SuspendThread(Handle); }
+    BOOL  Terminate(DWORD exitCode) { return TerminateThread(Handle, exitCode); }
 };
 #endif //DEBUGGER_THREAD_HPP

--- a/debugger/thread_manager.hpp
+++ b/debugger/thread_manager.hpp
@@ -3,7 +3,6 @@
 
 #include <stdexcept>
 #include <string.hpp>
-
 #include "thread.hpp"
 
 /*!
@@ -14,98 +13,98 @@
 class ThreadManager final
 {
 public:
-	struct ThreadNotFoundException				: std::runtime_error
-	{
-		ThreadId	const		TID;
-		ThreadNotFoundException(ThreadId tid) : TID(tid), 
-			std::runtime_error(Utilities::string_format("Thread [id = %u] not found.", tid)) {}
-	};
-	struct InvalidThreadOwnerIdException		: std::runtime_error 	
-	{
-		ProcessId	const		PID;
-		ThreadId	const		TID;
-		InvalidThreadOwnerIdException(ThreadId tid, ProcessId pid) : TID(tid), PID(pid),
-			std::runtime_error(Utilities::string_format("Thread [id = %u] owned by different process [id = %u].", tid, pid)) {}
-	};
+    struct ThreadNotFoundException : std::runtime_error
+    {
+        ThreadId const TID;
+        ThreadNotFoundException(ThreadId tid) : TID(tid), 
+            std::runtime_error(Utilities::string_format("Thread [id = %u] not found.", tid)) {}
+    };
+    struct InvalidThreadOwnerIdException : std::runtime_error
+    {
+        ProcessId const PID;
+        ThreadId  const TID;
+        InvalidThreadOwnerIdException(ThreadId tid, ProcessId pid) : TID(tid), PID(pid),
+            std::runtime_error(Utilities::string_format("Thread [id = %u] owned by different process [id = %u].", tid, pid)) {}
+    };
 
-	std::map<ThreadId, Thread>		Threads;
+    std::map<ThreadId, Thread> Threads;
 private:
-	ProcessHandle					_process;
-	ProcessId							_processId;
+    ProcessHandle _process;
+    ProcessId     _processId;
 public:
-	ThreadManager(ThreadManager& other)						= delete;
-	ThreadManager& operator=(ThreadManager& other)		= delete;
+    ThreadManager(ThreadManager& other)            = delete;
+    ThreadManager& operator=(ThreadManager& other) = delete;
 
-	~ThreadManager() = default;
-	ThreadManager() noexcept = default;
-	ThreadManager(ProcessHandle process)
-		: _process(process), _processId(GetProcessId(process)) { }
-	ThreadManager(ThreadManager&& other) noexcept :
-		_process(std::exchange(other._process, nullptr)),
-		_processId(std::exchange(other._processId, 0)),
-		Threads(std::exchange(other.Threads, {})) { }
+    ~ThreadManager() = default;
+    ThreadManager() noexcept = default;
+    ThreadManager(ProcessHandle process)
+        : _process(process), _processId(GetProcessId(process)) { }
+    ThreadManager(ThreadManager&& other) noexcept :
+        _process(std::exchange(other._process, nullptr)),
+        _processId(std::exchange(other._processId, 0)),
+        Threads(std::exchange(other.Threads, {})) { }
 
-	ThreadManager& operator=(ThreadManager&& other) noexcept
-	{
-		_process = std::exchange(other._process, nullptr);
-		_processId = std::exchange(other._processId, 0);
-		Threads = std::exchange(other.Threads, {});
-		return  *this;
-	}
-	Thread& operator[](ThreadId id)
-	{
-		if (auto const it = Threads.find(id); it != Threads.end())
-			return it->second;
-		throw ThreadNotFoundException{ id };
-	};
+    ThreadManager& operator=(ThreadManager&& other) noexcept
+    {
+        _process = std::exchange(other._process, nullptr);
+        _processId = std::exchange(other._processId, 0);
+        Threads = std::exchange(other.Threads, {});
+        return  *this;
+    }
+    Thread& operator[](ThreadId id)
+    {
+        if (auto const it = Threads.find(id); it != Threads.end())
+            return it->second;
+        throw ThreadNotFoundException{ id };
+    };
 
-	Thread& FindOrEmplace(ThreadId id, ThreadHandle handle) noexcept
-	{
-		if (auto const it = Threads.find(id); it != Threads.end())
-			return it->second;
-		return Threads.emplace(id, Thread(handle)).first->second;
-	}
-	Thread& Append(Thread& thread)
-	{
-		if (thread.OwnerId != _processId)
-			throw InvalidThreadOwnerIdException{ thread.Id, thread.OwnerId };
-		if (auto const it = Threads.find(thread.Id); it != Threads.end())
-			return thread;
-		return Threads.emplace(thread.Id, &thread).first->second;
-	}
-	Thread& Create(
-		ThreadStartRoutine				routineFunc,
-		ThreadProcessParameter		parameter = nullptr,
-		ThreadCreationFlags			creationFlags = CREATE_SUSPENDED
-	) {
-		ThreadId id;
-		ThreadHandle handle = CreateRemoteThread(
-			_process, nullptr, 0,
-			routineFunc, parameter,
-			creationFlags,
-			&id);
-		return Threads.emplace(id, handle).first->second;
-	}
-	bool Close(ThreadId id)
-	{
-		if (auto const it = Threads.find(id); it != Threads.end())
-		{
-			Thread& threadInfo = it->second;
-			Threads.erase(it);
-			return true;
-		}
-		return false;
-	}
-	bool Remove(Thread& thread)
-	{
-		if (auto const it = Threads.find(thread.Id); it != Threads.end())
-		{
-			Thread& threadInfo = it->second;
-			Threads.erase(it);
-			return true;
-		}
-		return false;
-	}
+    Thread& FindOrEmplace(ThreadId id, ThreadHandle handle) noexcept
+    {
+        if (auto const it = Threads.find(id); it != Threads.end())
+            return it->second;
+        return Threads.emplace(id, Thread(handle)).first->second;
+    }
+    Thread& Append(Thread& thread)
+    {
+        if (thread.OwnerId != _processId)
+            throw InvalidThreadOwnerIdException{ thread.Id, thread.OwnerId };
+        if (auto const it = Threads.find(thread.Id); it != Threads.end())
+            return thread;
+        return Threads.emplace(thread.Id, &thread).first->second;
+    }
+    Thread& Create(
+        ThreadStartRoutine     routineFunc,
+        ThreadProcessParameter parameter = nullptr,
+        ThreadCreationFlags    creationFlags = CREATE_SUSPENDED
+    ) {
+        ThreadId id;
+        ThreadHandle handle = CreateRemoteThread(
+            _process, nullptr, 0,
+            routineFunc, parameter,
+            creationFlags,
+            &id);
+        return Threads.emplace(id, handle).first->second;
+    }
+    bool Close(ThreadId id)
+    {
+        if (auto const it = Threads.find(id); it != Threads.end())
+        {
+            Thread& threadInfo = it->second;
+            Threads.erase(it);
+            return true;
+        }
+        return false;
+    }
+    bool Remove(Thread& thread)
+    {
+        if (auto const it = Threads.find(thread.Id); it != Threads.end())
+        {
+            Thread& threadInfo = it->second;
+            Threads.erase(it);
+            return true;
+        }
+        return false;
+    }
 };
 
 #endif //DEBUGGER_THREAD_MANAGER_HPP

--- a/debugger/typedefs.hpp
+++ b/debugger/typedefs.hpp
@@ -5,14 +5,14 @@
 #include <Windows.h>
 //#undef WIN32_LEAN_AND_MEAN
 
-using ProcessHandle					= HANDLE;
-using ProcessId							= DWORD;
-using ThreadHandle					= HANDLE;
-using ThreadId							= DWORD;
-using ContextFlags						= DWORD;
-using ThreadStartRoutine			= LPTHREAD_START_ROUTINE;
-using ThreadProcessParameter	= LPVOID;
-using ThreadCreationFlags			= DWORD;
-using Address								= void*;
+using ProcessHandle          = HANDLE;
+using ProcessId              = DWORD;
+using ThreadHandle           = HANDLE;
+using ThreadId               = DWORD;
+using ContextFlags           = DWORD;
+using ThreadStartRoutine     = LPTHREAD_START_ROUTINE;
+using ThreadProcessParameter = LPVOID;
+using ThreadCreationFlags    = DWORD;
+using Address                = void*;
 
 #endif //DEBUGGER_TYPEDEFS_HPP

--- a/debugger/virtual_memory_handle.hpp
+++ b/debugger/virtual_memory_handle.hpp
@@ -3,7 +3,6 @@
 
 #include <stdexcept>
 #include <string.hpp>
-
 #include "typedefs.hpp"
 
 /*!
@@ -15,132 +14,132 @@
 class VirtualMemoryHandle final
 {
 public:
-	struct OutOfRangeException		: std::runtime_error 
-	{
-		VirtualMemoryHandle			const&	Handle;
-		void*									const		Where;
-		size_t								const		Size;
+    struct OutOfRangeException : std::runtime_error 
+    {
+        VirtualMemoryHandle const& Handle;
+        void*               const  Where;
+        size_t              const  Size;
 
-		OutOfRangeException(VirtualMemoryHandle const& handle, void* pWhere, size_t size)	:
-			Handle(handle), Where(pWhere), Size(size),
-			std::runtime_error(Utilities::string_format("Out of range while access VMH [address = 0x%x] at 0x%x, count: %u", (DWORD) Handle[0], (DWORD) pWhere, size)) {}
-	};
-	struct WriteMemoryException		: std::runtime_error
-	{
-		VirtualMemoryHandle			const&	Handle;
-		void*									const		Where;
-		size_t								const		Size;
-		size_t								const		WrittenSize;
-		DWORD								const		LastError;
+        OutOfRangeException(VirtualMemoryHandle const& handle, void* pWhere, size_t size) :
+            Handle(handle), Where(pWhere), Size(size),
+            std::runtime_error(Utilities::string_format("Out of range while access VMH [address = 0x%x] at 0x%x, count: %u", (DWORD) Handle[0], (DWORD) pWhere, size)) {}
+    };
+    struct WriteMemoryException : std::runtime_error
+    {
+        VirtualMemoryHandle const& Handle;
+        void*               const  Where;
+        size_t              const  Size;
+        size_t              const  WrittenSize;
+        DWORD               const  LastError;
 
-		WriteMemoryException(VirtualMemoryHandle const& handle, void* pWhere, size_t size, size_t writtenSize)	:
-			Handle(handle), Where(pWhere), Size(size), WrittenSize(writtenSize), LastError(GetLastError()),
-			std::runtime_error(Utilities::string_format("VMH Write error [address = 0x%x] at 0x%x, count: %u, written: %u", (DWORD) Handle[0], (DWORD) pWhere, size, writtenSize)) {}
-	};
-	struct ReadMemoryException		: std::runtime_error
-	{
-		VirtualMemoryHandle			const&	Handle;
-		void*									const		Where;
-		size_t								const		Size;
-		size_t								const		ReaddenSize;
-		DWORD								const		LastError;
+        WriteMemoryException(VirtualMemoryHandle const& handle, void* pWhere, size_t size, size_t writtenSize) :
+            Handle(handle), Where(pWhere), Size(size), WrittenSize(writtenSize), LastError(GetLastError()),
+            std::runtime_error(Utilities::string_format("VMH Write error [address = 0x%x] at 0x%x, count: %u, written: %u", (DWORD) Handle[0], (DWORD) pWhere, size, writtenSize)) {}
+    };
+    struct ReadMemoryException : std::runtime_error
+    {
+        VirtualMemoryHandle const& Handle;
+        void*               const  Where;
+        size_t              const  Size;
+        size_t              const  ReaddenSize;
+        DWORD               const  LastError;
 
-		ReadMemoryException(VirtualMemoryHandle const& handle, void* pWhere, size_t size, size_t readdenSize)	:
-			Handle(handle), Where(pWhere), Size(size), ReaddenSize(readdenSize), LastError(GetLastError()),
-			std::runtime_error(Utilities::string_format("VMH Read error [address = 0x%x] at 0x%x, count: %u, readden: %u", (DWORD) Handle[0], (DWORD) pWhere, size, readdenSize)) {}
-	};
+        ReadMemoryException(VirtualMemoryHandle const& handle, void* pWhere, size_t size, size_t readdenSize) :
+            Handle(handle), Where(pWhere), Size(size), ReaddenSize(readdenSize), LastError(GetLastError()),
+            std::runtime_error(Utilities::string_format("VMH Read error [address = 0x%x] at 0x%x, count: %u, readden: %u", (DWORD) Handle[0], (DWORD) pWhere, size, readdenSize)) {}
+    };
 private:
-	LPVOID		_value			{ nullptr };
-	HANDLE		_process		{ nullptr };
-	SIZE_T		_size				= 0;
-	bool			_freeMemory = true;
+    LPVOID _value      { nullptr };
+    HANDLE _process    { nullptr };
+    SIZE_T _size       = 0;
+    bool   _freeMemory = true;
 public:
-	VirtualMemoryHandle() noexcept;
-	VirtualMemoryHandle(HANDLE process,  SIZE_T size, bool freeMemory = true) noexcept : VirtualMemoryHandle(process, nullptr, size, freeMemory) { }
-	VirtualMemoryHandle(HANDLE process, LPVOID address, SIZE_T size, bool freeMemory = true) noexcept
-		: _process(process), _freeMemory(freeMemory)
-	{
-		if (process && size) 
-		{
-			this->_value = VirtualAllocEx(process, address, size, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-			_size = size;
-		}
-	}
-	VirtualMemoryHandle(LPVOID allocated, SIZE_T size, HANDLE process, bool freeMemory = true) noexcept
-		: _value(allocated), _process(process), _size(size), _freeMemory(freeMemory) { }
-	
-	VirtualMemoryHandle(VirtualMemoryHandle&& other) noexcept :
-		_value(std::exchange(other._value, nullptr)),
-		_process(std::exchange(other._process, nullptr)),
-	    _size(std::exchange(other._size, 0)),
-		_freeMemory(other._freeMemory) { }
-	VirtualMemoryHandle& operator=(VirtualMemoryHandle&& other) noexcept
-	{
-		if(this != &other)
-		{
-			_value = std::exchange(other._value, nullptr);
-			_process = std::exchange(other._process, nullptr);
-			_size = std::exchange(other._size, 0);
-			_freeMemory = other._freeMemory;
-		}
-		return *this;
-	}
+    VirtualMemoryHandle() noexcept;
+    VirtualMemoryHandle(HANDLE process, SIZE_T size, bool freeMemory = true) noexcept : VirtualMemoryHandle(process, nullptr, size, freeMemory) { }
+    VirtualMemoryHandle(HANDLE process, LPVOID address, SIZE_T size, bool freeMemory = true) noexcept
+        : _process(process), _freeMemory(freeMemory)
+    {
+        if (process && size) 
+        {
+            this->_value = VirtualAllocEx(process, address, size, MEM_RESERVE | MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+            _size = size;
+        }
+    }
+    VirtualMemoryHandle(LPVOID allocated, SIZE_T size, HANDLE process, bool freeMemory = true) noexcept
+        : _value(allocated), _process(process), _size(size), _freeMemory(freeMemory) { }
+    
+    VirtualMemoryHandle(VirtualMemoryHandle&& other) noexcept :
+        _value(std::exchange(other._value, nullptr)),
+        _process(std::exchange(other._process, nullptr)),
+        _size(std::exchange(other._size, 0)),
+        _freeMemory(other._freeMemory) { }
+    VirtualMemoryHandle& operator=(VirtualMemoryHandle&& other) noexcept
+    {
+        if(this != &other)
+        {
+            _value      = std::exchange(other._value, nullptr);
+            _process    = std::exchange(other._process, nullptr);
+            _size       = std::exchange(other._size, 0);
+            _freeMemory = other._freeMemory;
+        }
+        return *this;
+    }
 
-	VirtualMemoryHandle(VirtualMemoryHandle const&) = delete;
-	VirtualMemoryHandle& operator=(VirtualMemoryHandle& other) = delete;
-	
-	~VirtualMemoryHandle() noexcept
-	{
-		if (_freeMemory && this->_value && this->_process)			
-			VirtualFreeEx(this->_process, this->_value, 0, MEM_RELEASE);			
-	}
+    VirtualMemoryHandle(VirtualMemoryHandle const&) = delete;
+    VirtualMemoryHandle& operator=(VirtualMemoryHandle& other) = delete;
+    
+    ~VirtualMemoryHandle() noexcept
+    {
+        if (_freeMemory && this->_value && this->_process)
+            VirtualFreeEx(this->_process, this->_value, 0, MEM_RELEASE);
+    }
 
-	friend bool operator==(VirtualMemoryHandle const& lhs, VirtualMemoryHandle const& rhs)
-	{	return (lhs._process == rhs._process) && (lhs._value == rhs._value);	}
+    friend bool operator==(VirtualMemoryHandle const& lhs, VirtualMemoryHandle const& rhs)
+    {    return (lhs._process == rhs._process) && (lhs._value == rhs._value);    }
 
-	size_t Size() const noexcept { return _size; }
-	BYTE* Pointer(size_t offset = 0) const noexcept { return static_cast<BYTE*>(this->_value) + offset; }
-	BYTE* operator[](size_t offset) const {  return static_cast<BYTE*>(_value) + offset; }
-	
-	void Write(void* const data, size_t count, size_t offset = 0) const
-	{
-		BYTE* dest = operator[](offset);
-		BYTE* pLast = dest + count;
-	
-		BYTE* max = operator[](_size);
-		if (max < pLast)
-			throw OutOfRangeException { *this, (void*) dest, count };
-		SIZE_T writtenCount = 0;
-		const bool result = WriteProcessMemory(_process, dest, data, count, &writtenCount) != FALSE;
-		if (!result)
-			throw WriteMemoryException { *this, (void*) dest, count, writtenCount };
-		if (writtenCount != count)
-			throw WriteMemoryException { *this, (void*) dest, count, writtenCount };
-	}	
-	void Read(size_t offset, size_t count, void* const buffer) const
-	{
-		BYTE* pFirst = operator[](offset);
-		BYTE* pLast = pFirst + count;
-	
-		BYTE* max = operator[](_size);
-		if (max < pLast)
-			throw OutOfRangeException { *this, (void*) pFirst, count };
-	
-		SIZE_T readdenBytes;
-		const bool result = ReadProcessMemory(_process, pFirst, buffer, count, &readdenBytes) != FALSE;
-		if (!result)
-			throw ReadMemoryException { *this, (void*) pFirst, count, readdenBytes };
-		if (readdenBytes != count)
-			throw ReadMemoryException { *this, (void*) pFirst, count, readdenBytes };
-	}
+    size_t Size() const noexcept { return _size; }
+    BYTE* Pointer(size_t offset = 0) const noexcept { return static_cast<BYTE*>(this->_value) + offset; }
+    BYTE* operator[](size_t offset) const {  return static_cast<BYTE*>(_value) + offset; }
+    
+    void Write(void* const data, size_t count, size_t offset = 0) const
+    {
+        BYTE* dest = operator[](offset);
+        BYTE* pLast = dest + count;
+    
+        BYTE* max = operator[](_size);
+        if (max < pLast)
+            throw OutOfRangeException { *this, (void*) dest, count };
+        SIZE_T writtenCount = 0;
+        const bool result = WriteProcessMemory(_process, dest, data, count, &writtenCount) != FALSE;
+        if (!result)
+            throw WriteMemoryException { *this, (void*) dest, count, writtenCount };
+        if (writtenCount != count)
+            throw WriteMemoryException { *this, (void*) dest, count, writtenCount };
+    }    
+    void Read(size_t offset, size_t count, void* const buffer) const
+    {
+        BYTE* pFirst = operator[](offset);
+        BYTE* pLast = pFirst + count;
+    
+        BYTE* max = operator[](_size);
+        if (max < pLast)
+            throw OutOfRangeException { *this, (void*) pFirst, count };
+    
+        SIZE_T readdenBytes;
+        const bool result = ReadProcessMemory(_process, pFirst, buffer, count, &readdenBytes) != FALSE;
+        if (!result)
+            throw ReadMemoryException { *this, (void*) pFirst, count, readdenBytes };
+        if (readdenBytes != count)
+            throw ReadMemoryException { *this, (void*) pFirst, count, readdenBytes };
+    }
 
-	bool IsOwned(Address address) const noexcept
-	{
-		Address const		min		= _value;
-		Address const		max		= reinterpret_cast<BYTE*>(min) + _size;
+    bool IsOwned(Address address) const noexcept
+    {
+        Address const min = _value;
+        Address const max = reinterpret_cast<BYTE*>(min) + _size;
 
-		return address >= min && address < max;
-	}
+        return address >= min && address < max;
+    }
 };
 
 #endif //DEBUGGER_VIRTUAL_MEMORY_HANDLE_HPP

--- a/include/Syringe.h
+++ b/include/Syringe.h
@@ -1,12 +1,12 @@
 /*
-	SYRINGE.H
-	---------
-	Holds macros, structures, classes that are necessary to interact with Syringe correctly.
-																						-pd
-	---------
-	It was extended for new injector features like hooks on dynamic linking libraries.
-	Also SYR_VER macro removed.
-																						-Multfinite
+    SYRINGE.H
+    ---------
+    Holds macros, structures, classes that are necessary to interact with Syringe correctly.
+                                                                                        -pd
+    ---------
+    It was extended for new injector features like hooks on dynamic linking libraries.
+    Also SYR_VER macro removed.
+                                                                                        -Multfinite
 */
 
 #ifndef SYRINGE_H
@@ -16,208 +16,208 @@
 
 class LimitedRegister {
 protected:
-	DWORD data;
+    DWORD data;
 
-	WORD* wordData() {
-		return reinterpret_cast<WORD*>(&this->data);
-	}
+    WORD* wordData() {
+        return reinterpret_cast<WORD*>(&this->data);
+    }
 
-	BYTE* byteData() {
-		return reinterpret_cast<BYTE*>(&this->data);
-	}
+    BYTE* byteData() {
+        return reinterpret_cast<BYTE*>(&this->data);
+    }
 
 public:
-	WORD Get16() {
-		return *this->wordData();
-	}
+    WORD Get16() {
+        return *this->wordData();
+    }
 
-	template<typename T>
-	inline T Get() {
-		return *reinterpret_cast<T*>(&this->data);
-	}
+    template<typename T>
+    inline T Get() {
+        return *reinterpret_cast<T*>(&this->data);
+    }
 
-	template<typename T>
-	inline void Set(T value) {
-		this->data = DWORD(value);
-	}
+    template<typename T>
+    inline void Set(T value) {
+        this->data = DWORD(value);
+    }
 
-	void Set16(WORD value) {
-		*this->wordData() = value;
-	}
+    void Set16(WORD value) {
+        *this->wordData() = value;
+    }
 };
 
 class ExtendedRegister : public LimitedRegister {
 public:
-	BYTE Get8Hi() {
-		return this->byteData()[1];
-	}
+    BYTE Get8Hi() {
+        return this->byteData()[1];
+    }
 
-	BYTE Get8Lo() {
-		return this->byteData()[0];
-	}
+    BYTE Get8Lo() {
+        return this->byteData()[0];
+    }
 
-	void Set8Hi(BYTE value) {
-		this->byteData()[1] = value;
-	}
+    void Set8Hi(BYTE value) {
+        this->byteData()[1] = value;
+    }
 
-	void Set8Lo(BYTE value) {
-		this->byteData()[0] = value;
-	}
+    void Set8Lo(BYTE value) {
+        this->byteData()[0] = value;
+    }
 };
 
 class StackRegister : public ExtendedRegister {
 public:
-	template<typename T>
-	inline T* lea(int byteOffset) {
-		return reinterpret_cast<T*>(static_cast<DWORD>(this->data + static_cast<DWORD>(byteOffset)));
-	}
+    template<typename T>
+    inline T* lea(int byteOffset) {
+        return reinterpret_cast<T*>(static_cast<DWORD>(this->data + static_cast<DWORD>(byteOffset)));
+    }
 
-	inline DWORD lea(int byteOffset) {
-		return static_cast<DWORD>(this->data + static_cast<DWORD>(byteOffset));
-	}
+    inline DWORD lea(int byteOffset) {
+        return static_cast<DWORD>(this->data + static_cast<DWORD>(byteOffset));
+    }
 
-	template<typename T>
-	inline T At(int byteOffset) {
-		return *reinterpret_cast<T*>(this->data + static_cast<DWORD>(byteOffset));
-	}
+    template<typename T>
+    inline T At(int byteOffset) {
+        return *reinterpret_cast<T*>(this->data + static_cast<DWORD>(byteOffset));
+    }
 
-	template<typename T>
-	inline void At(int byteOffset, T value) {
-		*reinterpret_cast<T*>(this->data + static_cast<DWORD>(byteOffset)) = value;
-	}
+    template<typename T>
+    inline void At(int byteOffset, T value) {
+        *reinterpret_cast<T*>(this->data + static_cast<DWORD>(byteOffset)) = value;
+    }
 };
 
 //Macros to make the following a lot easier
 #define REG_SHORTCUTS(reg) \
-	inline DWORD reg() \
-		{ return this->_ ## reg.Get<DWORD>(); } \
-	template<typename T> inline T reg() \
-		{ return this->_ ## reg.Get<T>(); } \
-	template<typename T> inline void reg(T value) \
-		{ this->_ ## reg.Set(value); } \
+    inline DWORD reg() \
+        { return this->_ ## reg.Get<DWORD>(); } \
+    template<typename T> inline T reg() \
+        { return this->_ ## reg.Get<T>(); } \
+    template<typename T> inline void reg(T value) \
+        { this->_ ## reg.Set(value); } \
 
 #define REG_SHORTCUTS_X(r) \
-	DWORD r ## X() \
-		{ return this->_E ## r ## X.Get16(); } \
-	void r ## X(WORD value) \
-		{ this->_E ## r ## X.Set16(value); } \
+    DWORD r ## X() \
+        { return this->_E ## r ## X.Get16(); } \
+    void r ## X(WORD value) \
+        { this->_E ## r ## X.Set16(value); } \
 
 #define REG_SHORTCUTS_HL(r) \
-	DWORD r ## H() \
-		{ return this->_E ## r ## X.Get8Hi(); } \
-	void r ## H(BYTE value) \
-		{ this->_E ## r ## X.Set8Hi(value); } \
-	DWORD r ## L() \
-		{ return this->_E ## r ## X.Get8Lo(); } \
-	void r ## L(BYTE value) \
-		{ this->_E ## r ## X.Set8Lo(value); } \
+    DWORD r ## H() \
+        { return this->_E ## r ## X.Get8Hi(); } \
+    void r ## H(BYTE value) \
+        { this->_E ## r ## X.Set8Hi(value); } \
+    DWORD r ## L() \
+        { return this->_E ## r ## X.Get8Lo(); } \
+    void r ## L(BYTE value) \
+        { this->_E ## r ## X.Set8Lo(value); } \
 
 #define REG_SHORTCUTS_XHL(r) \
-	REG_SHORTCUTS_X(r); \
-	REG_SHORTCUTS_HL(r); \
+    REG_SHORTCUTS_X(r); \
+    REG_SHORTCUTS_HL(r); \
 
 //A pointer to this class is passed as an argument to EXPORT functions
 class REGISTERS
 {
 private:
-	DWORD	origin;
-	DWORD	flags;
+    DWORD            origin;
+    DWORD            flags;
 
-	LimitedRegister _EDI;
-	LimitedRegister _ESI;
-	StackRegister _EBP;
-	StackRegister _ESP;
-	ExtendedRegister _EBX;
-	ExtendedRegister _EDX;
-	ExtendedRegister _ECX;
-	ExtendedRegister _EAX;
+    LimitedRegister  _EDI;
+    LimitedRegister  _ESI;
+    StackRegister    _EBP;
+    StackRegister    _ESP;
+    ExtendedRegister _EBX;
+    ExtendedRegister _EDX;
+    ExtendedRegister _ECX;
+    ExtendedRegister _EAX;
 
 public:
-	DWORD Origin() {
-		return this->origin;
-	}
+    DWORD Origin() {
+        return this->origin;
+    }
 
-	DWORD EFLAGS() {
-		return this->flags;
-	}
+    DWORD EFLAGS() {
+        return this->flags;
+    }
 
-	void EFLAGS(DWORD value) {
-		this->flags = value;
-	}
+    void EFLAGS(DWORD value) {
+        this->flags = value;
+    }
 
-	REG_SHORTCUTS(EAX);
-	REG_SHORTCUTS(EBX);
-	REG_SHORTCUTS(ECX);
-	REG_SHORTCUTS(EDX);
-	REG_SHORTCUTS(ESI);
-	REG_SHORTCUTS(EDI);
-	REG_SHORTCUTS(ESP);
-	REG_SHORTCUTS(EBP);
+    REG_SHORTCUTS(EAX);
+    REG_SHORTCUTS(EBX);
+    REG_SHORTCUTS(ECX);
+    REG_SHORTCUTS(EDX);
+    REG_SHORTCUTS(ESI);
+    REG_SHORTCUTS(EDI);
+    REG_SHORTCUTS(ESP);
+    REG_SHORTCUTS(EBP);
 
-	REG_SHORTCUTS_XHL(A);
-	REG_SHORTCUTS_XHL(B);
-	REG_SHORTCUTS_XHL(C);
-	REG_SHORTCUTS_XHL(D);
+    REG_SHORTCUTS_XHL(A);
+    REG_SHORTCUTS_XHL(B);
+    REG_SHORTCUTS_XHL(C);
+    REG_SHORTCUTS_XHL(D);
 
-	template<typename T>
-	inline T lea_Stack(int offset) {
-		return reinterpret_cast<T>(this->_ESP.lea(offset));
-	}
+    template<typename T>
+    inline T lea_Stack(int offset) {
+        return reinterpret_cast<T>(this->_ESP.lea(offset));
+    }
 
-	template<>
-	inline DWORD lea_Stack(int offset) {
-		return this->_ESP.lea(offset);
-	}
+    template<>
+    inline DWORD lea_Stack(int offset) {
+        return this->_ESP.lea(offset);
+    }
 
-	template<>
-	inline int lea_Stack(int offset) {
-		return static_cast<int>(this->_ESP.lea(offset));
-	}
+    template<>
+    inline int lea_Stack(int offset) {
+        return static_cast<int>(this->_ESP.lea(offset));
+    }
 
-	template<typename T>
-	inline T& ref_Stack(int offset) {
-		return *this->lea_Stack<T*>(offset);
-	}
+    template<typename T>
+    inline T& ref_Stack(int offset) {
+        return *this->lea_Stack<T*>(offset);
+    }
 
-	template<typename T>
-	inline T Stack(int offset) {
-		return this->_ESP.At<T>(offset);
-	}
+    template<typename T>
+    inline T Stack(int offset) {
+        return this->_ESP.At<T>(offset);
+    }
 
-	DWORD Stack32(int offset) {
-		return this->_ESP.At<DWORD>(offset);
-	}
+    DWORD Stack32(int offset) {
+        return this->_ESP.At<DWORD>(offset);
+    }
 
-	WORD Stack16(int offset) {
-		return this->_ESP.At<WORD>(offset);
-	}
+    WORD Stack16(int offset) {
+        return this->_ESP.At<WORD>(offset);
+    }
 
-	BYTE Stack8(int offset) {
-		return this->_ESP.At<BYTE>(offset);
-	}
+    BYTE Stack8(int offset) {
+        return this->_ESP.At<BYTE>(offset);
+    }
 
-	template<typename T>
-	inline T Base(int offset) {
-		return this->_EBP.At<T>(offset);
-	}
+    template<typename T>
+    inline T Base(int offset) {
+        return this->_EBP.At<T>(offset);
+    }
 
-	template<typename T>
-	inline void Stack(int offset, T value) {
-		this->_ESP.At(offset, value);
-	}
+    template<typename T>
+    inline void Stack(int offset, T value) {
+        this->_ESP.At(offset, value);
+    }
 
-	void Stack16(int offset, WORD value) {
-		this->_ESP.At(offset, value);
-	}
+    void Stack16(int offset, WORD value) {
+        this->_ESP.At(offset, value);
+    }
 
-	void Stack8(int offset, BYTE value) {
-		this->_ESP.At(offset, value);
-	}
+    void Stack8(int offset, BYTE value) {
+        this->_ESP.At(offset, value);
+    }
 
-	template<typename T>
-	inline void Base(int offset, T value) {
-		this->_EBP.At(offset, value);
-	}
+    template<typename T>
+    inline void Base(int offset, T value) {
+        this->_EBP.At(offset, value);
+    }
 };
 
 //Use this for DLL export functions
@@ -229,14 +229,14 @@ public:
 //Handshake definitions
 struct SyringeHandshakeInfo
 {
-	int cbSize;
-	int num_hooks;
-	unsigned int checksum;
-	DWORD exeFilesize;
-	DWORD exeTimestamp;
-	unsigned int exeCRC;
-	int cchMessage;
-	char* Message;
+    int          cbSize;
+    int          num_hooks;
+    unsigned int checksum;
+    DWORD        exeFilesize;
+    DWORD        exeTimestamp;
+    unsigned int exeCRC;
+    int          cchMessage;
+    char*        Message;
 };
 
 #define SYRINGE_HANDSHAKE(pInfo) extern "C" __declspec(dllexport) HRESULT __cdecl SyringeHandshake(SyringeHandshakeInfo* pInfo)
@@ -246,8 +246,8 @@ struct SyringeHandshakeInfo
 */
 namespace SyringeData 
 {
-	namespace	Hooks	{};
-	namespace	Hosts		{};
+    namespace    Hooks    {};
+    namespace    Hosts        {};
 };
 
 #define declhost(exename, checksum) \

--- a/include/context.hpp
+++ b/include/context.hpp
@@ -10,65 +10,65 @@
 
 namespace Injector
 {
-	using std::string;
+    using std::string;
 
-	/*!
-	* @author Multfinite Multfinite@gmail.com
-	* @brief This class should be used in injected dll to get access to injection context.
-	*/
-	struct InjectionContextHandle
-	{
-		HANDLE			ShMemHandle;
-		BYTE*			ShMemPtr;
+    /*!
+    * @author Multfinite Multfinite@gmail.com
+    * @brief This class should be used in injected dll to get access to injection context.
+    */
+    struct InjectionContextHandle
+    {
+        HANDLE   ShMemHandle;
+        BYTE*    ShMemPtr;
 
-		size_t*			DataSize;
-		size_t*			ExecutableNameSize;
-		char*			ExecutableNameInStruct;
-		size_t*			ArgumentsSize;
-		char*			ArgumentsInStruct;
-		size_t*			NameLength;
-		size_t*			ModuleSize;
-		HMODULE*	Handles;
-		char*			Names;
+        size_t*  DataSize;
+        size_t*  ExecutableNameSize;
+        char*    ExecutableNameInStruct;
+        size_t*  ArgumentsSize;
+        char*    ArgumentsInStruct;
+        size_t*  NameLength;
+        size_t*  ModuleSize;
+        HMODULE* Handles;
+        char*    Names;
 
-		InjectionContextHandle()
-		{
-			DWORD	processId				= GetProcessId(GetCurrentProcess());
-			string	memName				= "InjContext-" + std::to_string(processId);
+        InjectionContextHandle()
+        {
+            DWORD  processId           = GetProcessId(GetCurrentProcess());
+            string memName             = "InjContext-" + std::to_string(processId);
 
-			ShMemHandle					= OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, memName.data());
-			ShMemPtr							= static_cast<BYTE*>(MapViewOfFile(ShMemHandle, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(size_t)));
-			size_t const dataSize			= *reinterpret_cast<size_t*>(ShMemPtr);
-			UnmapViewOfFile(ShMemPtr);
+            ShMemHandle                = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, memName.data());
+            ShMemPtr                   = static_cast<BYTE*>(MapViewOfFile(ShMemHandle, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(size_t)));
+            size_t const dataSize      = *reinterpret_cast<size_t*>(ShMemPtr);
+            UnmapViewOfFile(ShMemPtr);
 
-			ShMemPtr							= static_cast<BYTE*>(MapViewOfFile(ShMemHandle, FILE_MAP_ALL_ACCESS, 0, 0, dataSize));
-			DataSize							= offset_ptr<size_t>(ShMemPtr, 0);
-			ExecutableNameSize			= offset_ptr<size_t>(DataSize, sizeof(size_t));
-			ExecutableNameInStruct		= offset_ptr<char>(ExecutableNameSize, sizeof(size_t));
-			ArgumentsSize					= offset_ptr<size_t>(ExecutableNameInStruct, *ExecutableNameSize + 1);
-			ArgumentsInStruct				= offset_ptr<char>(ArgumentsSize, sizeof(size_t));
-			NameLength						= offset_ptr<size_t>(ArgumentsInStruct, *ArgumentsSize + 1);
-			ModuleSize						= offset_ptr<size_t>(NameLength, sizeof(size_t));
-			Handles								= offset_ptr<HMODULE>(ModuleSize, sizeof(size_t));
-			Names								= offset_ptr<char>(Handles, sizeof(HMODULE) * *ModuleSize);
-		}
-		~InjectionContextHandle()
-		{
-			UnmapViewOfFile(ShMemPtr);
-			CloseHandle(ShMemHandle);
+            ShMemPtr                   = static_cast<BYTE*>(MapViewOfFile(ShMemHandle, FILE_MAP_ALL_ACCESS, 0, 0, dataSize));
+            DataSize                   = offset_ptr<size_t>(ShMemPtr, 0);
+            ExecutableNameSize         = offset_ptr<size_t>(DataSize, sizeof(size_t));
+            ExecutableNameInStruct     = offset_ptr<char>(ExecutableNameSize, sizeof(size_t));
+            ArgumentsSize              = offset_ptr<size_t>(ExecutableNameInStruct, *ExecutableNameSize + 1);
+            ArgumentsInStruct          = offset_ptr<char>(ArgumentsSize, sizeof(size_t));
+            NameLength                 = offset_ptr<size_t>(ArgumentsInStruct, *ArgumentsSize + 1);
+            ModuleSize                 = offset_ptr<size_t>(NameLength, sizeof(size_t));
+            Handles                    = offset_ptr<HMODULE>(ModuleSize, sizeof(size_t));
+            Names                      = offset_ptr<char>(Handles, sizeof(HMODULE) * *ModuleSize);
+        }
+        ~InjectionContextHandle()
+        {
+            UnmapViewOfFile(ShMemPtr);
+            CloseHandle(ShMemHandle);
 
-			ShMemPtr							= nullptr;
-			DataSize							= nullptr;
-			ExecutableNameSize			= nullptr;
-			ExecutableNameInStruct		= nullptr;
-			ArgumentsSize					= nullptr;
-			ArgumentsInStruct				= nullptr;
-			NameLength						= nullptr;
-			ModuleSize						= nullptr;
-			Handles								= nullptr;
-			Names								= nullptr;
-		}
-	};
+            ShMemPtr               = nullptr;
+            DataSize               = nullptr;
+            ExecutableNameSize     = nullptr;
+            ExecutableNameInStruct = nullptr;
+            ArgumentsSize          = nullptr;
+            ArgumentsInStruct      = nullptr;
+            NameLength             = nullptr;
+            ModuleSize             = nullptr;
+            Handles                = nullptr;
+            Names                  = nullptr;
+        }
+    };
 }
 
 #endif //INJECTOR_CONTEXT_HPP

--- a/include/declaration.hpp
+++ b/include/declaration.hpp
@@ -7,50 +7,50 @@
 #pragma warning(disable : 4324)
 struct alignas(16) HookDecl
 {
-	DWORD			Address;
-	size_t			Size;
-	DWORD			FunctionNamePtr;
+    DWORD  Address;
+    size_t Size;
+    DWORD  FunctionNamePtr;
 };
 
 struct alignas(32) ExtendedHookDecl
 {
-	DWORD			Address;
-	size_t			Size;
-	DWORD			FunctionNamePtr;
-	DWORD			ModuleNamePtr;
-	unsigned int	ModuleChecksum;
+    DWORD        Address;
+    size_t       Size;
+    DWORD        FunctionNamePtr;
+    DWORD        ModuleNamePtr;
+    unsigned int ModuleChecksum;
 };
 
 struct alignas(16) HostDecl
 {
-	unsigned int	Checksum;
-	DWORD			NamePtr;
+    unsigned int Checksum;
+    DWORD        NamePtr;
 };
 #pragma warning(pop)
 #else
 #pragma pack(push, 16)
 #pragma warning(push)
-#pragma warning( disable : 4324)
+#pragma warning(disable : 4324)
 __declspec(align(16)) struct HookDecl
 {
-	unsigned int	Address;
-	unsigned int	Size;
-	const char*	FunctionNamePtr;
+    unsigned int Address;
+    unsigned int Size;
+    const char*  FunctionNamePtr;
 };
 
 __declspec(align(32)) struct ExtendedHookDecl
 {
-	unsigned int	Address;
-	unsigned int	Size;
-	const char*	FunctionNamePtr;
-	const char*	ModuleNamePtr;
-	unsigned int	ModuleChecksum;
+    unsigned int    Address;
+    unsigned int    Size;
+    const char*    FunctionNamePtr;
+    const char*    ModuleNamePtr;
+    unsigned int    ModuleChecksum;
 };
 
 __declspec(align(16)) struct HostDecl
 {
-	unsigned int	Checksum;
-	const char*	NamePtr;
+    unsigned int    Checksum;
+    const char*    NamePtr;
 };
 #pragma warning(pop)
 #pragma pack(pop)

--- a/include/elements.hpp
+++ b/include/elements.hpp
@@ -3,13 +3,13 @@
 
 namespace Injector
 {
-	static constexpr const char*	InitializerFunctionName							= "Initialize";
-	static constexpr const char*	GenericHooksPESectionName					= ".syhks00";
-	static constexpr const char*	HostsPESectionName								= ".syexe00";
-	static constexpr const char*	ExtendedHooksPESectionName					= ".syhks01";
-	static constexpr const char*	HandshakeFunctionName						= "SyringeHandshake";	
-	static constexpr size_t			MaxFilenameLength								= 0x100;
-	static constexpr size_t			MaxFunctionNameLength						= 0x100u;
+    static constexpr const char*  InitializerFunctionName    = "Initialize";
+    static constexpr const char*  GenericHooksPESectionName  = ".syhks00";
+    static constexpr const char*  HostsPESectionName         = ".syexe00";
+    static constexpr const char*  ExtendedHooksPESectionName = ".syhks01";
+    static constexpr const char*  HandshakeFunctionName      = "SyringeHandshake";    
+    static constexpr       size_t MaxFilenameLength          = 0x100;
+    static constexpr       size_t MaxFunctionNameLength      = 0x100u;
 }
 
 #endif // INJECTOR_ELEMENTS_HPP

--- a/injector/asm.hpp
+++ b/injector/asm.hpp
@@ -3,10 +3,10 @@
 
 #include "framework.hpp"
 
-static constexpr size_t MaxLibraryNameLength		= 0x100u;
-static constexpr size_t MaxProcNameLength			= 0x100u;
+static constexpr size_t MaxLibraryNameLength     = 0x100u;
+static constexpr size_t MaxProcNameLength        = 0x100u;
 
-static size_t constexpr CallR32InstructionLength	= 5;
+static size_t constexpr CallR32InstructionLength = 5;
 
 #define INT3 0xCC
 // trap to debugger interrupt opcode. (INT3)
@@ -20,256 +20,256 @@ static size_t constexpr CallR32InstructionLength	= 5;
 // uint32 placeholdfer
 #define INIT_DWORD INIT, INIT, INIT, INIT
 
-#define MASK8 0xFF
+#define MASK8  0xFF
 #define MASK32 0xFF, 0xFF, 0xFF, 0xFF
 
-#define JO_R8(rel8)				0x70, rel8
-#define JNO_R8(rel8)				0x71, rel8
-#define JB_R8(rel8)				0x72, rel8
-#define JNB_R8(rel8)				0x73, rel8
-#define JZ_R8(rel8)				0x74, rel8
-#define JNZ_R8(rel8)				0x75, rel8
-#define JBE_R8(rel8)				0x76, rel8
-#define JNBE_R8(rel8)			0x77, rel8
-#define JS_R8(rel8)				0x78, rel8
-#define JNS_R8(rel8)				0x79, rel8
-#define JP_R8(rel8)				0x7A, rel8
-#define JNP_R8(rel8)				0x7B, rel8
-#define JL_R8(rel8)				0x7C, rel8
-#define JNL_R8(rel8)				0x7D, rel8
-#define JNG_R8(rel8)				0x7E, rel8
-#define JG_R8(rel8)				0x7F, rel8
-#define JCXZ(rel8)					0xE3, rel8
-#define LOOPNZ(rel8)				0xE0, rel8
-#define LOOPZ(rel8)				0xE1, rel8
-#define LOOP(rel8)					0xE2, rel8
-#define CALL_R32(rel32)		0xE8, rel32
-#define JMP_R32(rel32)			0xE9, rel32
-#define JMPF_R32(rel32)		0xEA, rel32
-#define	JMP_R8(rel8)				0xEB, rel8
-#define JO_R32(rel32)			0x0F, 0x80, rel32
-#define JNO_R32(rel32)			0x0F, 0x81, rel32
-#define JB_R32(rel32)			0x0F, 0x82, rel32
-#define JNB_R32(rel32)			0x0F, 0x83, rel32
-#define JZ_R32(rel32)			0x0F, 0x84, rel32
-#define JNZ_R32(rel32)			0x0F, 0x85, rel32
-#define JBE_R32(rel32)			0x0F, 0x86, rel32
-#define JNBE_R32(rel32)		0x0F, 0x87, rel32
-#define JS_R32(rel32)			0x0F, 0x88, rel32
-#define JNS_R32(rel32)			0x0F, 0x89, rel32
-#define JP_R32(rel32)			0x0F, 0x8A, rel32
-#define JNP_R32(rel32)			0x0F, 0x8B, rel32
-#define JL_R32(rel32)			0x0F, 0x8C, rel32
-#define JNL_R32(rel32)			0x0F, 0x8D, rel32
-#define JNG_R32(rel32)			0x0F, 0x8E, rel32
-#define JG_R32(rel32)			0x0F, 0x8F, rel32
+#define JO_R8(rel8)     0x70, rel8
+#define JNO_R8(rel8)    0x71, rel8
+#define JB_R8(rel8)     0x72, rel8
+#define JNB_R8(rel8)    0x73, rel8
+#define JZ_R8(rel8)     0x74, rel8
+#define JNZ_R8(rel8)    0x75, rel8
+#define JBE_R8(rel8)    0x76, rel8
+#define JNBE_R8(rel8)   0x77, rel8
+#define JS_R8(rel8)     0x78, rel8
+#define JNS_R8(rel8)    0x79, rel8
+#define JP_R8(rel8)     0x7A, rel8
+#define JNP_R8(rel8)    0x7B, rel8
+#define JL_R8(rel8)     0x7C, rel8
+#define JNL_R8(rel8)    0x7D, rel8
+#define JNG_R8(rel8)    0x7E, rel8
+#define JG_R8(rel8)     0x7F, rel8
+#define JCXZ(rel8)      0xE3, rel8
+#define LOOPNZ(rel8)    0xE0, rel8
+#define LOOPZ(rel8)     0xE1, rel8
+#define LOOP(rel8)      0xE2, rel8
+#define CALL_R32(rel32) 0xE8, rel32
+#define JMP_R32(rel32)  0xE9, rel32
+#define JMPF_R32(rel32) 0xEA, rel32
+#define JMP_R8(rel8)    0xEB, rel8
+#define JO_R32(rel32)   0x0F, 0x80, rel32
+#define JNO_R32(rel32)  0x0F, 0x81, rel32
+#define JB_R32(rel32)   0x0F, 0x82, rel32
+#define JNB_R32(rel32)  0x0F, 0x83, rel32
+#define JZ_R32(rel32)   0x0F, 0x84, rel32
+#define JNZ_R32(rel32)  0x0F, 0x85, rel32
+#define JBE_R32(rel32)  0x0F, 0x86, rel32
+#define JNBE_R32(rel32) 0x0F, 0x87, rel32
+#define JS_R32(rel32)   0x0F, 0x88, rel32
+#define JNS_R32(rel32)  0x0F, 0x89, rel32
+#define JP_R32(rel32)   0x0F, 0x8A, rel32
+#define JNP_R32(rel32)  0x0F, 0x8B, rel32
+#define JL_R32(rel32)   0x0F, 0x8C, rel32
+#define JNL_R32(rel32)  0x0F, 0x8D, rel32
+#define JNG_R32(rel32)  0x0F, 0x8E, rel32
+#define JG_R32(rel32)   0x0F, 0x8F, rel32
 
-#define PUSH_EAX					0x50
-#define POP_EAX					0x58
-#define PUSH_ECX					0x51
-#define POP_ECX					0x59
-#define PUSH_EDX					0x52
-#define POP_EDX					0x5A
-#define PUSHAD					0x60
-#define POPAD						0x61
-#define PUSHFD						0x9C
-#define POPFD						0x9D
-#define PUSH_ESP					0x54
-#define ADD_ESP(imm8)		0x83, 0xC4, imm8 
-#define PUSH_INTO_STACK(imm32) 0x68, imm32
+#define PUSH_EAX                      0x50
+#define POP_EAX                       0x58
+#define PUSH_ECX                      0x51
+#define POP_ECX                       0x59
+#define PUSH_EDX                      0x52
+#define POP_EDX                       0x5A
+#define PUSHAD                        0x60
+#define POPAD                         0x61
+#define PUSHFD                        0x9C
+#define POPFD                         0x9D
+#define PUSH_ESP                      0x54
+#define ADD_ESP(imm8)                 0x83, 0xC4, imm8 
+#define PUSH_INTO_STACK(imm32)        0x68, imm32
 #define ADD_PTR32_IMM32(ptr32, imm32) 0x81, 0x05, ptr32, imm32
-#define MOV_EAX_TO(ptr32)	0xA3, ptr32
-#define MOV_TO_EAX(ptr32)	0XB8, ptr32
-#define TEST_EAX_EAX			0x85, 0xC0
+#define MOV_EAX_TO(ptr32)             0xA3, ptr32
+#define MOV_TO_EAX(ptr32)             0XB8, ptr32
+#define TEST_EAX_EAX                  0x85, 0xC0
 
-#define JMP_PTR32(ptr32)		0xFF, 0x25, ptr32
-#define CALL_PTR32(ptr32)	0xFF, 0x15, ptr32
+#define JMP_PTR32(ptr32)  0xFF, 0x25, ptr32
+#define CALL_PTR32(ptr32) 0xFF, 0x15, ptr32
 
-#define CALL_EAX					0xFF, 0xD0
+#define CALL_EAX                      0xFF, 0xD0
 #define CMP_PTR32_IMM32(ptr32, imm32) 0x83, 0x3D, ptr32, imm32
 
 struct invalid_jump_offset_error : std::runtime_error
 {
-	int64_t	const Value;
-	size_t	const Size;
-	invalid_jump_offset_error(int64_t value) : std::runtime_error("JUMP/CALL offset is invalid"), Value(value), Size(sizeof(int32_t)) {}
-	invalid_jump_offset_error(int64_t value, size_t size) : std::runtime_error("JUMP/CALL offset is invalid"), Value(value), Size(size) {}
+    int64_t const Value;
+    size_t  const Size;
+    invalid_jump_offset_error(int64_t value) : std::runtime_error("JUMP/CALL offset is invalid"), Value(value), Size(sizeof(int32_t)) {}
+    invalid_jump_offset_error(int64_t value, size_t size) : std::runtime_error("JUMP/CALL offset is invalid"), Value(value), Size(size) {}
 };
 
 inline int32_t __fastcall relative_offset(Address pFrom, Address pTo, size_t cmdSize = 0)
 {
-	auto const offset		= reinterpret_cast<int64_t>(pTo) - (reinterpret_cast<int64_t>(pFrom) + (int64_t) cmdSize);
-	if (offset <= INT32_MAX && offset >= INT32_MIN)
-		return offset;
-	throw invalid_jump_offset_error{ offset };
+    auto const offset = reinterpret_cast<int64_t>(pTo) - (reinterpret_cast<int64_t>(pFrom) + (int64_t) cmdSize);
+    if (offset <= INT32_MAX && offset >= INT32_MIN)
+        return offset;
+    throw invalid_jump_offset_error{ offset };
 }
 
 inline Address __fastcall restore_address(Address pFrom, int32_t offset, size_t cmdSize = 0)
 {
-	int32_t const pTo	= reinterpret_cast<int32_t>(pFrom) + offset + cmdSize;
-	return reinterpret_cast<Address>(pTo);
+    int32_t const pTo    = reinterpret_cast<int32_t>(pFrom) + offset + cmdSize;
+    return reinterpret_cast<Address>(pTo);
 }
 
 // newOffset = (oldOffset + pOld) - pNew
 inline int32_t __fastcall correct_relative_offset(int32_t oldOffset, Address pOld, Address pNew)
 {
-	int64_t		diff = reinterpret_cast<int64_t>(pOld) - reinterpret_cast<int64_t>(pNew);
-	int64_t		offset = oldOffset + diff;
-	if (offset <= INT32_MAX && offset >= INT32_MIN)
-		return offset;
-	throw invalid_jump_offset_error{ offset };
+    int64_t        diff = reinterpret_cast<int64_t>(pOld) - reinterpret_cast<int64_t>(pNew);
+    int64_t        offset = oldOffset + diff;
+    if (offset <= INT32_MAX && offset >= INT32_MIN)
+        return offset;
+    throw invalid_jump_offset_error{ offset };
 }
 
 struct _rel_cmd
 {
-	std::string					Mnemonic;
-	std::vector<BYTE>		Command;
-	
-	size_t						Size;
-	size_t						OffsetStart;
+    std::string       Mnemonic;
+    std::vector<BYTE> Command;
+    
+    size_t            Size;
+    size_t            OffsetStart;
 
-	_rel_cmd(std::string mnemonic, size_t size, size_t offsetStart, std::vector<BYTE> command) 
-		: Mnemonic(mnemonic), Size(size), OffsetStart(offsetStart), Command(command)
-	{}
-	_rel_cmd() = default;
+    _rel_cmd(std::string mnemonic, size_t size, size_t offsetStart, std::vector<BYTE> command) 
+        : Mnemonic(mnemonic), Size(size), OffsetStart(offsetStart), Command(command)
+    {}
+    _rel_cmd() = default;
 };
 struct relative_jump_info
 {
-	bool				IsRelativeJump;
-	// Offset in bytes from command start to jump command offset 
-	size_t			Offset;
-	_rel_cmd		Cmd;
+    bool     IsRelativeJump;
+    // Offset in bytes from command start to jump command offset 
+    size_t   Offset;
+    _rel_cmd Cmd;
 
-	relative_jump_info() : IsRelativeJump(false) {}
-	relative_jump_info(_rel_cmd cmd, size_t offset) : IsRelativeJump(true), Offset(offset), Cmd(cmd) {}
+    relative_jump_info() : IsRelativeJump(false) {}
+    relative_jump_info(_rel_cmd cmd, size_t offset) : IsRelativeJump(true), Offset(offset), Cmd(cmd) {}
 
-	bool operator!()	const		{ return !IsRelativeJump; }
-	operator bool()	const		{ return IsRelativeJump; }
+    bool operator!() const { return !IsRelativeJump; }
+    operator bool()  const { return IsRelativeJump; }
 };
 
 inline std::vector<_rel_cmd> get_eip_affected_instruction_with_relative_offset()
 {
-	return std::vector<_rel_cmd>
-	{
-		{ "JCXZ"		, 2, 1		, { JCXZ(MASK8)				}	},
-		{ "LOOPNZ"	, 2, 1		, { LOOPNZ(MASK8)			}	},
-		{ "LOOPZ"		, 2, 1		, { LOOPZ(MASK8)				}	},
-		{ "LOOP"		, 2, 1		, { LOOP(MASK8)				}	},
+    return std::vector<_rel_cmd>
+    {
+        { "JCXZ",   2, 1, { JCXZ(MASK8)      } },
+        { "LOOPNZ", 2, 1, { LOOPNZ(MASK8)    } },
+        { "LOOPZ",  2, 1, { LOOPZ(MASK8)     } },
+        { "LOOP",   2, 1, { LOOP(MASK8)      } },
 
-		{ "JO"			, 2, 1		, { JO_R8(MASK8)				}	},
-		{ "JNO"			, 2, 1		, { JNO_R8(MASK8)			}	},
-		{ "JB"			, 2, 1		, { JB_R8(MASK8)				}	},
-		{ "JNB"			, 2, 1		, { JNB_R8(MASK8)			}	},
-		{ "JZ"			, 2, 1		, { JZ_R8(MASK8)				}	},
-		{ "JNZ"			, 2, 1		, { JNZ_R8(MASK8)			}	},
-		{ "JBE"			, 2, 1		, { JBE_R8(MASK8)			}	},
-		{ "JNBE"		, 2, 1		, { JNBE_R8(MASK8)			}	},
-		{ "JS"			, 2, 1		, { JS_R8(MASK8)				}	},
-		{ "JNS"			, 2, 1		, { JNS_R8(MASK8)			}	},
-		{ "JP"			, 2, 1		, { JP_R8(MASK8)				}	},
-		{ "JNP"			, 2, 1		, { JNP_R8(MASK8)			}	},
-		{ "JL"			, 2, 1		, { JL_R8(MASK8)				}	},
-		{ "JNL"			, 2, 1		, { JNL_R8(MASK8)			}	},
-		{ "JNG"			, 2, 1		, { JNG_R8(MASK8)			}	},
-		{ "JG"			, 2, 1		, { JG_R8(MASK8)				}	},
-		{ "JMP"			, 2, 1		, { JMP_R8(MASK8)			}	},
+        { "JO",     2, 1, { JO_R8(MASK8)     } },
+        { "JNO",    2, 1, { JNO_R8(MASK8)    } },
+        { "JB",     2, 1, { JB_R8(MASK8)     } },
+        { "JNB",    2, 1, { JNB_R8(MASK8)    } },
+        { "JZ",     2, 1, { JZ_R8(MASK8)     } },
+        { "JNZ",    2, 1, { JNZ_R8(MASK8)    } },
+        { "JBE",    2, 1, { JBE_R8(MASK8)    } },
+        { "JNBE",   2, 1, { JNBE_R8(MASK8)   } },
+        { "JS",     2, 1, { JS_R8(MASK8)     } },
+        { "JNS",    2, 1, { JNS_R8(MASK8)    } },
+        { "JP",     2, 1, { JP_R8(MASK8)     } },
+        { "JNP",    2, 1, { JNP_R8(MASK8)    } },
+        { "JL",     2, 1, { JL_R8(MASK8)     } },
+        { "JNL",    2, 1, { JNL_R8(MASK8)    } },
+        { "JNG",    2, 1, { JNG_R8(MASK8)    } },
+        { "JG",     2, 1, { JG_R8(MASK8)     } },
+        { "JMP",    2, 1, { JMP_R8(MASK8)    } },
 
-		{ "JO"			, 4, 2		, { JO_R32(MASK32)			}	},
-		{ "JNO"			, 4, 2		, { JNO_R32(MASK32)		}	},
-		{ "JB"			, 4, 2		, { JB_R32(MASK32)			}	},
-		{ "JNB"			, 4, 2		, { JNB_R32(MASK32)		}	},
-		{ "JZ"			, 4, 2		, { JZ_R32(MASK32)			}	},
-		{ "JNZ"			, 4, 2		, { JNZ_R32(MASK32)		}	},
-		{ "JBE"			, 4, 2		, { JBE_R32(MASK32)			}	},
-		{ "JNBE"		, 4, 2		, { JNBE_R32(MASK32)		}	},
-		{ "JS"			, 4, 2		, { JS_R32(MASK32)			}	},
-		{ "JNS"			, 4, 2		, { JNS_R32(MASK32)		}	},
-		{ "JP"			, 4, 2		, { JP_R32(MASK32)			}	},
-		{ "JNP"			, 4, 2		, { JNP_R32(MASK32)			}	},
-		{ "JL"			, 4, 2		, { JL_R32(MASK32)			}	},
-		{ "JNL"			, 4, 2		, { JNL_R32(MASK32)			}	},
-		{ "JNG"			, 4, 2		, { JNG_R32(MASK32)		}	},
-		{ "JG"			, 4, 2		, { JG_R32(MASK32)			}	},
-		{ "JMP"			, 4, 1		, { JMP_R32(MASK32)		}	},
+        { "JO",     4, 2, { JO_R32(MASK32)   } },
+        { "JNO",    4, 2, { JNO_R32(MASK32)  } },
+        { "JB",     4, 2, { JB_R32(MASK32)   } },
+        { "JNB",    4, 2, { JNB_R32(MASK32)  } },
+        { "JZ",     4, 2, { JZ_R32(MASK32)   } },
+        { "JNZ",    4, 2, { JNZ_R32(MASK32)  } },
+        { "JBE",    4, 2, { JBE_R32(MASK32)  } },
+        { "JNBE",   4, 2, { JNBE_R32(MASK32) } },
+        { "JS",     4, 2, { JS_R32(MASK32)   } },
+        { "JNS",    4, 2, { JNS_R32(MASK32)  } },
+        { "JP",     4, 2, { JP_R32(MASK32)   } },
+        { "JNP",    4, 2, { JNP_R32(MASK32)  } },
+        { "JL",     4, 2, { JL_R32(MASK32)   } },
+        { "JNL",    4, 2, { JNL_R32(MASK32)  } },
+        { "JNG",    4, 2, { JNG_R32(MASK32)  } },
+        { "JG",     4, 2, { JG_R32(MASK32)   } },
+        { "JMP",    4, 1, { JMP_R32(MASK32)  } },
 
-		{ "CALL"		, 4, 1		, { CALL_R32(MASK32)		}	},
-	};
+        { "CALL",   4, 1, { CALL_R32(MASK32) } },
+    };
 }
 
 inline _rel_cmd find_rel_cmd(std::string mnemonic, size_t size)
 {
-	auto instructions = get_eip_affected_instruction_with_relative_offset();
-	auto iter = std::find_if(instructions.cbegin(), instructions.cend(), [&mnemonic, &size](const _rel_cmd& item) -> bool
-	{
-		return item.Mnemonic == mnemonic && item.Size == size;
-	});
-	if (iter == instructions.cend())
-		throw;
-	return *iter;
+    auto instructions = get_eip_affected_instruction_with_relative_offset();
+    auto iter = std::find_if(instructions.cbegin(), instructions.cend(), [&mnemonic, &size](const _rel_cmd& item) -> bool
+    {
+        return item.Mnemonic == mnemonic && item.Size == size;
+    });
+    if (iter == instructions.cend())
+        throw;
+    return *iter;
 }
 
 inline relative_jump_info is_relative_jump(std::vector<BYTE> command)
 {
-	for (auto& instruction : get_eip_affected_instruction_with_relative_offset())
-	{
-		if (instruction.Command.empty())								continue;
-		if (command.size() < instruction.Command.size())		continue;
-		bool ok = true;
-		for (size_t i = 0; i < instruction.OffsetStart; i++)
-		{
-			auto	a	= instruction.Command.at(i);
-			auto	b	= command.at(i);
-			ok			= a == b;
-			if (!ok)	break;
-		}
-		if (ok)
-			return relative_jump_info(instruction, 1);
-	}
-	return relative_jump_info{};
+    for (auto& instruction : get_eip_affected_instruction_with_relative_offset())
+    {
+        if (instruction.Command.empty())                 continue;
+        if (command.size() < instruction.Command.size()) continue;
+        bool ok = true;
+        for (size_t i = 0; i < instruction.OffsetStart; i++)
+        {
+            auto a = instruction.Command.at(i);
+            auto b = command.at(i);
+            ok     = a == b;
+            if (!ok) break;
+        }
+        if (ok)
+            return relative_jump_info(instruction, 1);
+    }
+    return relative_jump_info{};
 }
 
 template<typename T>
 inline T _get_relative_offset(std::vector<BYTE> command, size_t offset)
 {
-	T value = 0;
-	memcpy(&value, command.data() + offset, sizeof(T));
-	return value;
+    T value = 0;
+    memcpy(&value, command.data() + offset, sizeof(T));
+    return value;
 }
 inline int32_t get_relative_offset(std::vector<BYTE> command, relative_jump_info& rji)
 {
-	switch (rji.Cmd.Size)
-	{
-		case(1):		return _get_relative_offset<int8_t>(command, rji.Offset);
-		case(2):		return _get_relative_offset<int16_t>(command, rji.Offset);
-		case(4):		return _get_relative_offset<int32_t>(command, rji.Offset);
-		default:			throw;
-	}
+    switch (rji.Cmd.Size)
+    {
+        case(1): return _get_relative_offset<int8_t>(command, rji.Offset);
+        case(2): return _get_relative_offset<int16_t>(command, rji.Offset);
+        case(4): return _get_relative_offset<int32_t>(command, rji.Offset);
+        default: throw;
+    }
 }
 
 inline void set_relative_offset(std::vector<BYTE>& command, relative_jump_info& rji, int32_t value)
 {
-	switch (rji.Cmd.Size)
-	{
-		case(1):
-		{
-			if (value <= INT8_MAX && value >= INT8_MIN)
-				memcpy(command.data() + rji.Offset, &value, sizeof(int8_t));
-			else throw invalid_jump_offset_error { value, rji.Cmd.Size };
-		} break;
-		case(2):
-		{
-			if (value <= INT16_MAX && value >= INT16_MIN)
-				memcpy(command.data() + rji.Offset, &value, sizeof(int16_t));
-			else throw invalid_jump_offset_error { value, rji.Cmd.Size };
-		} break;
-		case(4):
-		{
-			if (value <= INT32_MAX && value >= INT32_MIN)
-				memcpy(command.data() + rji.Offset, &value, sizeof(int32_t));
-			else throw invalid_jump_offset_error { value, rji.Cmd.Size };
-		} break;
-		default: throw;
-	}
+    switch (rji.Cmd.Size)
+    {
+        case(1):
+        {
+            if (value <= INT8_MAX && value >= INT8_MIN)
+                memcpy(command.data() + rji.Offset, &value, sizeof(int8_t));
+            else throw invalid_jump_offset_error { value, rji.Cmd.Size };
+        } break;
+        case(2):
+        {
+            if (value <= INT16_MAX && value >= INT16_MIN)
+                memcpy(command.data() + rji.Offset, &value, sizeof(int16_t));
+            else throw invalid_jump_offset_error { value, rji.Cmd.Size };
+        } break;
+        case(4):
+        {
+            if (value <= INT32_MAX && value >= INT32_MIN)
+                memcpy(command.data() + rji.Offset, &value, sizeof(int32_t));
+            else throw invalid_jump_offset_error { value, rji.Cmd.Size };
+        } break;
+        default: throw;
+    }
 }
 
 #endif //INJECTOR_ASM_HPP

--- a/injector/configurator.hpp
+++ b/injector/configurator.hpp
@@ -11,301 +11,301 @@
 #include "context_emplacer.hpp"
 
 namespace Injector
-{	
-	using namespace Debugger;
-	using Breakpoint = DebugLoop::Breakpoint;
-	using namespace PECOFF;
+{
+    using namespace Debugger;
+    using Breakpoint = DebugLoop::Breakpoint;
+    using namespace PECOFF;
 
-	/*!
-	* @author multfinite
-	* @brief Implements the top behavior of injector. It wraps around debugger events when breakpoint reached.
-	* @brief Injection algorithm:
-	* @brief 1. Suspend main thread. Create a new thread for injection.
-	* @brief 2. Place 'waiter': a simple program which includes breakpoint, which will be trapped by debugger. Used for detecting steps.
-	* @brief 3. Wait for kernel32.dll
-	* @brief 4. Prepare a program to load all injectable modules: generate, write and execute. Extract all laoded handles from process.
-	* @brief 5. Prepare a program to retieve all hook function addresses: generate, write and execute. Extract all data and set it to hooks.
-	* @brief 6. Iterate all hooks, check their inejction conditions, checksums, module names and sort it. 
-	* @brief 7. Generate for each hooked address a program, which will execute all related hook functions. Then write program and write jumps.
-	* @brief 8. Assembly a context of execution (look for ContextEmplacer) and write it into shared memory: 'InjContext-$PID'. It is accessible from injected dlls.
-	* @brief 9. Terminate loader thread and resume main thread.
-	* @brief NOTE 1: Executable can be protected via ASLR. Injector does not support it (need to create an algorithm which will seek new bases and perform address correction). 
-	* @brief NOTE 2: Stack can be protected and then hook invocation to it will cause invalid data inside function.
-	*/
-	class Configurator final
-	{
-	public:
-		struct InvalidBaseAddressException : exception
-		{
-			LPVOID Preffered;
-			LPVOID Current;
-			InvalidBaseAddressException(LPVOID preffered, LPVOID current)	:
-				Preffered(preffered),
-				Current(current)
-			{}
-		};
-		// 
-		struct Kernel32InvalidBaseAddressException : InvalidBaseAddressException
-		{
-			Kernel32InvalidBaseAddressException(LPVOID preffered, LPVOID current) : InvalidBaseAddressException(preffered, current) {}
-		};
-		//https://docs.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization?view=msvc-170
-		struct DynamicBaseUnsupportedException : InvalidBaseAddressException
-		{
-			DynamicBaseUnsupportedException(LPVOID preffered, LPVOID current) : InvalidBaseAddressException(preffered, current) {}
-		};
-	private:		
-		//
-		PortableExecutable& _peFile;
-		DebugLoop& _debugger;
-		Kernel32 _kernel;
-		list<Module>& _modules;
+    /*!
+    * @author multfinite
+    * @brief Implements the top behavior of injector. It wraps around debugger events when breakpoint reached.
+    * @brief Injection algorithm:
+    * @brief 1. Suspend main thread. Create a new thread for injection.
+    * @brief 2. Place 'waiter': a simple program which includes breakpoint, which will be trapped by debugger. Used for detecting steps.
+    * @brief 3. Wait for kernel32.dll
+    * @brief 4. Prepare a program to load all injectable modules: generate, write and execute. Extract all laoded handles from process.
+    * @brief 5. Prepare a program to retieve all hook function addresses: generate, write and execute. Extract all data and set it to hooks.
+    * @brief 6. Iterate all hooks, check their inejction conditions, checksums, module names and sort it. 
+    * @brief 7. Generate for each hooked address a program, which will execute all related hook functions. Then write program and write jumps.
+    * @brief 8. Assembly a context of execution (look for ContextEmplacer) and write it into shared memory: 'InjContext-$PID'. It is accessible from injected dlls.
+    * @brief 9. Terminate loader thread and resume main thread.
+    * @brief NOTE 1: Executable can be protected via ASLR. Injector does not support it (need to create an algorithm which will seek new bases and perform address correction). 
+    * @brief NOTE 2: Stack can be protected and then hook invocation to it will cause invalid data inside function.
+    */
+    class Configurator final
+    {
+    public:
+        struct InvalidBaseAddressException : exception
+        {
+            LPVOID Preffered;
+            LPVOID Current;
+            InvalidBaseAddressException(LPVOID preffered, LPVOID current)    :
+                Preffered(preffered),
+                Current(current)
+            {}
+        };
+        // 
+        struct Kernel32InvalidBaseAddressException : InvalidBaseAddressException
+        {
+            Kernel32InvalidBaseAddressException(LPVOID preffered, LPVOID current) : InvalidBaseAddressException(preffered, current) {}
+        };
+        //https://docs.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization?view=msvc-170
+        struct DynamicBaseUnsupportedException : InvalidBaseAddressException
+        {
+            DynamicBaseUnsupportedException(LPVOID preffered, LPVOID current) : InvalidBaseAddressException(preffered, current) {}
+        };
+    private:        
+        //
+        PortableExecutable& _peFile;
+        DebugLoop&          _debugger;
+        Kernel32            _kernel;
+        list<Module>&       _modules;
 
-		string_view const& _arguments;
-		string_view const& _executableName;
-		
-		//InjectionContext _context;
-		//VirtualMemoryHandle& _contextVmh;
+        string_view const&  _arguments;
+        string_view const&  _executableName;
+        
+        //InjectionContext _context;
+        //VirtualMemoryHandle& _contextVmh;
 
-		WaiterCode _waiterCode;
-		VirtualMemoryHandle& _waiterVmh;
-		
-		ModuleRetriever* _moduleRetriever;
-		HookRetriever* _hookRetriever;
-		HookInjector* _hookInjector;
+        WaiterCode           _waiterCode;
+        VirtualMemoryHandle& _waiterVmh;
+        
+        ModuleRetriever* _moduleRetriever;
+        HookRetriever*   _hookRetriever;
+        HookInjector*    _hookInjector;
 
-		string _contextSharedMemoryName;
-		ContextEmplacer* _contextEmplacer;
+        string           _contextSharedMemoryName;
+        ContextEmplacer* _contextEmplacer;
 
-		Address _waiterBp;
-		Address _moduleRetrieverBp;
-		Address _hookRetrieverBp;
-		Address _initializerInjectorBp;
+        Address _waiterBp;
+        Address _moduleRetrieverBp;
+        Address _hookRetrieverBp;
+        Address _initializerInjectorBp;
 
-		Thread* _loaderThreadInfo;
+        Thread* _loaderThreadInfo;
 
-		VirtualMemoryHandle& _moduleHandle;
-		std::vector<VirtualMemoryHandle*> _hookHandles;
-		std::vector<VirtualMemoryHandle*> _stringHandles;
+        VirtualMemoryHandle&              _moduleHandle;
+        std::vector<VirtualMemoryHandle*> _hookHandles;
+        std::vector<VirtualMemoryHandle*> _stringHandles;
 
-		DllInfo* _kernelDll = nullptr;
-		VirtualMemoryHandle* _importTable;
-	public:
-		Configurator(
-			PortableExecutable& peFile,
-			DebugLoop& debugger, 
-			list<Module>& modules,
-			string_view const& arguments,
-			string_view const& executableName) :
-				_peFile(peFile),
-				_debugger(debugger),
-				_moduleHandle(debugger.Memory.Allocate(sizeof(Module) * modules.size())),
-				_modules(modules),
-				_arguments(arguments),
-				_executableName(executableName),
-				_waiterCode(), _waiterVmh(debugger.Memory.Allocate(WaiterCodeSize))
-		{
-			_waiterVmh.Write(&_waiterCode, WaiterCodeSize);
-			_debugger.OnProcessCreated += [this] (DebugLoop& sender) { OnProcessCreated(sender); };
-			_debugger.OnAccessViolation += [this](DebugLoop& sender, Thread& thread, Address address) { OnAccessViolation(sender, thread, address); };
-			_debugger.OnDllLoaded += [this] (DebugLoop& sender, DllInfo& dll) { OnDllLoaded(sender, dll); };
-		};
-		~Configurator()
-		{
-			if(_importTable)
-				_debugger.Memory.Free(*_importTable);
-			
-			for (VirtualMemoryHandle* vmh : _stringHandles)			
-				_debugger.Memory.Free(reference_cast(vmh));
-			for (VirtualMemoryHandle* vmh : _hookHandles)			
-				_debugger.Memory.Free(reference_cast(vmh));
-			
-			delete _moduleRetriever;
-			delete _hookRetriever;
-			delete _hookInjector;
-		}		
-		
-	private:		
-		void OnProcessCreated(DebugLoop& sender)
-		{
-			spdlog::info("Process created, configuring...");
+        DllInfo*             _kernelDll = nullptr;
+        VirtualMemoryHandle* _importTable;
+    public:
+        Configurator(
+            PortableExecutable& peFile,
+            DebugLoop& debugger, 
+            list<Module>& modules,
+            string_view const& arguments,
+            string_view const& executableName) :
+                _peFile(peFile),
+                _debugger(debugger),
+                _moduleHandle(debugger.Memory.Allocate(sizeof(Module) * modules.size())),
+                _modules(modules),
+                _arguments(arguments),
+                _executableName(executableName),
+                _waiterCode(), _waiterVmh(debugger.Memory.Allocate(WaiterCodeSize))
+        {
+            _waiterVmh.Write(&_waiterCode, WaiterCodeSize);
+            _debugger.OnProcessCreated += [this] (DebugLoop& sender) { OnProcessCreated(sender); };
+            _debugger.OnAccessViolation += [this](DebugLoop& sender, Thread& thread, Address address) { OnAccessViolation(sender, thread, address); };
+            _debugger.OnDllLoaded += [this] (DebugLoop& sender, DllInfo& dll) { OnDllLoaded(sender, dll); };
+        };
+        ~Configurator()
+        {
+            if(_importTable)
+                _debugger.Memory.Free(*_importTable);
 
-			_debugger.MainThread->Suspend();
-			
-			_loaderThreadInfo = &_debugger.ThreadMgr.Create(
-				static_cast<ThreadStartRoutine>(static_cast<Address>(_waiterVmh.Pointer())), 
-				nullptr, CREATE_SUSPENDED);
+            for (VirtualMemoryHandle* vmh : _stringHandles)
+                _debugger.Memory.Free(reference_cast(vmh));
+            for (VirtualMemoryHandle* vmh : _hookHandles)
+                _debugger.Memory.Free(reference_cast(vmh));
 
-			_waiterBp = _waiterVmh.Pointer(WaiterBreakpointOffset);
-			auto& wcbp = _debugger.AddBreakpoint(_waiterBp);
-			wcbp.OnReached += [this] (DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread) { OnWaiterBreakpoint(bp, sender, thread); };
-			
-			_loaderThreadInfo->GetContext(CONTEXT_FULL);
-			Address const nextInstruction = _waiterVmh.Pointer();
-			_loaderThreadInfo->Context.Eip = reinterpret_cast<DWORD>(nextInstruction);
-			_loaderThreadInfo->SetContext(CONTEXT_FULL);
-			
-			spdlog::info("Process configured, run loader thread and execute injected programs...");
-			_loaderThreadInfo->Resume();
-		}
+            delete _moduleRetriever;
+            delete _hookRetriever;
+            delete _hookInjector;
+        }
 
-		void OnDllLoaded(DebugLoop& sender, DllInfo& dllInfo)
-		{
-			spdlog::trace("[Debug event] dll \"{0}\" ({1}) loaded at [0x{2:x}], image size: {3} bytes, checksum: 0x{4:X} ({4:d})", 
-				dllInfo.FileName, dllInfo.FVI.OriginalFilename, 
-				(uint32_t) dllInfo.Handle, dllInfo.ImageSize, dllInfo.Checksum);
-			auto dllPath = std::filesystem::path{ dllInfo.FileName };
-			auto dllName = dllPath.filename().string();
-			if(strcmpi(dllName.c_str(), "kernel32.dll") == 0)
-			{
-				_kernelDll = &dllInfo;
+    private:
+        void OnProcessCreated(DebugLoop& sender)
+        {
+            spdlog::info("Process created, configuring...");
 
-				_kernel.GetProcAddressFunc = &GetProcAddress;
-				_kernel.LoadLibraryFunc = &LoadLibraryA;
-				_kernel.FreeLibraryFunc = &FreeLibrary;
-				
-				_importTable = &_debugger.Memory.Allocate(sizeof(Address) * 3);
-				_importTable->Write(&_kernel, sizeof(Kernel32));
+            _debugger.MainThread->Suspend();
 
-				_kernel.GetProcAddressFunc = reinterpret_cast<GetProcAddressFunction>(_importTable->Pointer(sizeof(Address) * 0));
-				_kernel.LoadLibraryFunc = reinterpret_cast<LoadLibraryFunction>(_importTable->Pointer(sizeof(Address) * 1));
-				_kernel.FreeLibraryFunc = reinterpret_cast<FreeLibraryFunction>(_importTable->Pointer(sizeof(Address) * 2));
+            _loaderThreadInfo = &_debugger.ThreadMgr.Create(
+                static_cast<ThreadStartRoutine>(static_cast<Address>(_waiterVmh.Pointer())), 
+                nullptr, CREATE_SUSPENDED);
 
-				spdlog::trace("::GetProcAddress = 0x{0:x}", (uint32_t) _kernel.GetProcAddressFunc);
-				spdlog::trace("::LoadLibraryA = 0x{0:x}", (uint32_t) _kernel.LoadLibraryFunc);
-				spdlog::trace("::FreeLibrary = 0x{0:x}", (uint32_t) _kernel.FreeLibraryFunc);
-			}
-		}
-		
-		//void OnThreadSingleStep(Debugger& dbg, Thread& thread, Address address)
-		void OnWaiterBreakpoint(DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
-		{
-			if(thread.Id != _loaderThreadInfo->Id)
-				return;
-			if(_kernelDll)
-			{
-				HMODULE const kernelHandle = GetModuleHandleA("kernel32.dll");
-				if(kernelHandle != _kernelDll->Base)
-					throw Kernel32InvalidBaseAddressException(kernelHandle, _kernelDll->Base);
-				
-				InitLL();
-			}
-			else
-			{
-				if(_debugger.Dlls.size() > 0)
-					throw;
-				_loaderThreadInfo->GetContext(CONTEXT_FULL);
-				Address const nextInstruction = _waiterVmh.Pointer();
-				_loaderThreadInfo->Context.Eip = reinterpret_cast<DWORD>(nextInstruction);			
-				_loaderThreadInfo->SetContext(CONTEXT_FULL);
-			}
-		}
+            _waiterBp = _waiterVmh.Pointer(WaiterBreakpointOffset);
+            auto& wcbp = _debugger.AddBreakpoint(_waiterBp);
+            wcbp.OnReached += [this] (DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread) { OnWaiterBreakpoint(bp, sender, thread); };
 
-		void InitLL()
-		{
-			spdlog::info("Prepare module loading program (it invokes LoadLibraryA for a list of modules)...");
-			
-			_moduleRetriever = new ModuleRetriever { _debugger.Memory, _kernel, _modules };
-			_moduleRetrieverBp = static_cast<BYTE*>(_moduleRetriever->breakpoint());
-			spdlog::trace("::breakpoint = [0x{0:x}]", (uint32_t) _moduleRetrieverBp);
-			auto& mrbp = _debugger.AddBreakpoint(_moduleRetrieverBp);
-			mrbp.OnReached += 
-				[this] (DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
-					{	OnLLBreakpoint(bp, sender, thread);	};
+            _loaderThreadInfo->GetContext(CONTEXT_FULL);
+            Address const nextInstruction = _waiterVmh.Pointer();
+            _loaderThreadInfo->Context.Eip = reinterpret_cast<DWORD>(nextInstruction);
+            _loaderThreadInfo->SetContext(CONTEXT_FULL);
 
-			_loaderThreadInfo->GetContext(CONTEXT_FULL);
-			Address const nextInstruction = _moduleRetriever->instruction();
-			_loaderThreadInfo->Context.Eip = reinterpret_cast<DWORD>(nextInstruction);			
-			_loaderThreadInfo->SetContext(CONTEXT_FULL);
-			spdlog::info("Run module loading program. (at [0x{0:x}])...", (uint32_t) nextInstruction);
-		}
-		
-		void OnLLBreakpoint(DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
-		{
-			spdlog::info("Module loading program executed.");
-			vector<HMODULE> handles;
-			handles.resize(_modules.size());
-			_moduleRetriever->ModuleHandlesVmh->Read(0, sizeof(HMODULE) * handles.size(), handles.data());
+            spdlog::info("Process configured, run loader thread and execute injected programs...");
+            _loaderThreadInfo->Resume();
+        }
 
-			for (size_t index = 0; index < _modules.size(); ++index)
-			{
-				Module& mdl = *std::next(_modules.begin(), index);
-				mdl.set_handle(handles[index]);
-			}
+        void OnDllLoaded(DebugLoop& sender, DllInfo& dllInfo)
+        {
+            spdlog::trace("[Debug event] dll \"{0}\" ({1}) loaded at [0x{2:x}], image size: {3} bytes, checksum: 0x{4:X} ({4:d})", 
+                dllInfo.FileName, dllInfo.FVI.OriginalFilename, 
+                (uint32_t) dllInfo.Handle, dllInfo.ImageSize, dllInfo.Checksum);
+            auto dllPath = std::filesystem::path{ dllInfo.FileName };
+            auto dllName = dllPath.filename().string();
+            if(strcmpi(dllName.c_str(), "kernel32.dll") == 0)
+            {
+                _kernelDll = &dllInfo;
 
-			spdlog::info("Prepare function retrievening program (It invoke GetProcAddress for a list of function names)...");
-			_hookRetriever = new HookRetriever { _debugger.Memory, _kernel, _modules };
-			_hookRetrieverBp = static_cast<BYTE*>(_hookRetriever->breakpoint());
-			spdlog::trace("::breakpoint = [0x{0:x}]", (uint32_t) _hookRetrieverBp);
-			auto& hrbp = _debugger.AddBreakpoint(_hookRetrieverBp);
-			hrbp.OnReached +=
-				[this] (DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
-					{	OnGPABreakpoint(bp, sender, thread);	};	
+                _kernel.GetProcAddressFunc = &GetProcAddress;
+                _kernel.LoadLibraryFunc = &LoadLibraryA;
+                _kernel.FreeLibraryFunc = &FreeLibrary;
 
-			thread.GetContext(CONTEXT_FULL);
-			Address const nextInstruction = _hookRetriever->instruction();
-			thread.Context.Eip = reinterpret_cast<DWORD>(nextInstruction);
-			thread.SetContext(CONTEXT_FULL);
-			spdlog::info("Run function retrievening program (at 0x{0:x})...", (uint32_t) nextInstruction);
-		}
+                _importTable = &_debugger.Memory.Allocate(sizeof(Address) * 3);
+                _importTable->Write(&_kernel, sizeof(Kernel32));
 
-		//DWORD _eip;
-		void OnGPABreakpoint(DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
-		{
-			spdlog::info("Function retrievening program executed.");
-			
-			vector<InitFunction> initFunctions; initFunctions.resize(_modules.size());
-			vector<HookFunction> hookFunctions; hookFunctions.resize(_hookRetriever->TotalHookCount);
+                _kernel.GetProcAddressFunc = reinterpret_cast<GetProcAddressFunction>(_importTable->Pointer(sizeof(Address) * 0));
+                _kernel.LoadLibraryFunc = reinterpret_cast<LoadLibraryFunction>(_importTable->Pointer(sizeof(Address) * 1));
+                _kernel.FreeLibraryFunc = reinterpret_cast<FreeLibraryFunction>(_importTable->Pointer(sizeof(Address) * 2));
 
-			_hookRetriever->InitFunctionsVmh->Read(0, sizeof(InitFunction) * initFunctions.size(), initFunctions.data());
-			_hookRetriever->HookFunctionsVmh->Read(0, sizeof(HookFunction) * hookFunctions.size(), hookFunctions.data());
+                spdlog::trace("::GetProcAddress = 0x{0:x}", (uint32_t) _kernel.GetProcAddressFunc);
+                spdlog::trace("::LoadLibraryA = 0x{0:x}", (uint32_t) _kernel.LoadLibraryFunc);
+                spdlog::trace("::FreeLibrary = 0x{0:x}", (uint32_t) _kernel.FreeLibraryFunc);
+            }
+        }
+        
+        //void OnThreadSingleStep(Debugger& dbg, Thread& thread, Address address)
+        void OnWaiterBreakpoint(DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
+        {
+            if(thread.Id != _loaderThreadInfo->Id)
+                return;
+            if(_kernelDll)
+            {
+                HMODULE const kernelHandle = GetModuleHandleA("kernel32.dll");
+                if(kernelHandle != _kernelDll->Base)
+                    throw Kernel32InvalidBaseAddressException(kernelHandle, _kernelDll->Base);
 
-			DWORD prefferedImageBase = _peFile.PEHeader.OptionalHeader.ImageBase;
-			DWORD currentImageBase = reinterpret_cast<DWORD>(_debugger.ProcessDebugInfo.lpBaseOfImage);
-			DWORD imageBaseOffset = prefferedImageBase - currentImageBase;
-			if(imageBaseOffset != 0)
-				throw DynamicBaseUnsupportedException(reinterpret_cast<LPVOID>(prefferedImageBase), reinterpret_cast<LPVOID>(currentImageBase));
-			
-			size_t initf = 0;
-			size_t thkIndex = 0;			
-			for (size_t index = 0; index < _modules.size(); ++index)
-			{
-				Module& mdl = *std::next(_modules.begin(), index);
-				mdl.InitFunction = initFunctions[index];
-				if(mdl.InitFunction)				
-					initf++;				
+                InitLL();
+            }
+            else
+            {
+                if(_debugger.Dlls.size() > 0)
+                    throw;
+                _loaderThreadInfo->GetContext(CONTEXT_FULL);
+                Address const nextInstruction = _waiterVmh.Pointer();
+                _loaderThreadInfo->Context.Eip = reinterpret_cast<DWORD>(nextInstruction);            
+                _loaderThreadInfo->SetContext(CONTEXT_FULL);
+            }
+        }
 
-				for (auto& hook : mdl.Hooks)
-				{
-					hook.Placement = reinterpret_cast<Address>(reinterpret_cast<DWORD>(hook.Placement) + imageBaseOffset);
-					
-					HookFunction const func =  hookFunctions[thkIndex++];
-					hook.Function = func;
-				}
-			}
-			_hookInjector = new HookInjector(_debugger, _modules);
+        void InitLL()
+        {
+            spdlog::info("Prepare module loading program (it invokes LoadLibraryA for a list of modules)...");
+            
+            _moduleRetriever = new ModuleRetriever { _debugger.Memory, _kernel, _modules };
+            _moduleRetrieverBp = static_cast<BYTE*>(_moduleRetriever->breakpoint());
+            spdlog::trace("::breakpoint = [0x{0:x}]", (uint32_t) _moduleRetrieverBp);
+            auto& mrbp = _debugger.AddBreakpoint(_moduleRetrieverBp);
+            mrbp.OnReached += 
+                [this] (DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
+                    {    OnLLBreakpoint(bp, sender, thread);    };
 
-			DWORD processId = _debugger.ProcessInfo.dwProcessId;
-			_contextSharedMemoryName = "InjContext-" + std::to_string(processId);
-			
-			spdlog::info("Inject context into shared memory (\"{}\")...", _contextSharedMemoryName);
-			_contextEmplacer = new ContextEmplacer(
-				_executableName.data(),
-				_arguments,
-				_contextSharedMemoryName.data(),
-				_debugger.Dlls	);
-			spdlog::info("Context injected.");
-			
-			spdlog::info("Terminate loader thread...");
-			thread.Terminate(0);
-			spdlog::info("Process configured - resume main thread.");
-			_debugger.MainThread->Resume();
-		}
+            _loaderThreadInfo->GetContext(CONTEXT_FULL);
+            Address const nextInstruction = _moduleRetriever->instruction();
+            _loaderThreadInfo->Context.Eip = reinterpret_cast<DWORD>(nextInstruction);            
+            _loaderThreadInfo->SetContext(CONTEXT_FULL);
+            spdlog::info("Run module loading program. (at [0x{0:x}])...", (uint32_t) nextInstruction);
+        }
+        
+        void OnLLBreakpoint(DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
+        {
+            spdlog::info("Module loading program executed.");
+            vector<HMODULE> handles;
+            handles.resize(_modules.size());
+            _moduleRetriever->ModuleHandlesVmh->Read(0, sizeof(HMODULE) * handles.size(), handles.data());
 
-		void OnAccessViolation(DebugLoop& dbgLoop, Thread& thread, Address address)
-		{
-			spdlog::critical("Access Violation at 0x{0:x} in thread {0:d}", (uint32_t) address, thread.Id);
-		}
-	};
+            for (size_t index = 0; index < _modules.size(); ++index)
+            {
+                Module& mdl = *std::next(_modules.begin(), index);
+                mdl.set_handle(handles[index]);
+            }
+
+            spdlog::info("Prepare function retrievening program (It invoke GetProcAddress for a list of function names)...");
+            _hookRetriever = new HookRetriever { _debugger.Memory, _kernel, _modules };
+            _hookRetrieverBp = static_cast<BYTE*>(_hookRetriever->breakpoint());
+            spdlog::trace("::breakpoint = [0x{0:x}]", (uint32_t) _hookRetrieverBp);
+            auto& hrbp = _debugger.AddBreakpoint(_hookRetrieverBp);
+            hrbp.OnReached +=
+                [this] (DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
+                    { OnGPABreakpoint(bp, sender, thread); };    
+
+            thread.GetContext(CONTEXT_FULL);
+            Address const nextInstruction = _hookRetriever->instruction();
+            thread.Context.Eip = reinterpret_cast<DWORD>(nextInstruction);
+            thread.SetContext(CONTEXT_FULL);
+            spdlog::info("Run function retrievening program (at 0x{0:x})...", (uint32_t) nextInstruction);
+        }
+
+        //DWORD _eip;
+        void OnGPABreakpoint(DebugLoop::Breakpoint& bp, DebugLoop& sender, Thread& thread)
+        {
+            spdlog::info("Function retrievening program executed.");
+
+            vector<InitFunction> initFunctions; initFunctions.resize(_modules.size());
+            vector<HookFunction> hookFunctions; hookFunctions.resize(_hookRetriever->TotalHookCount);
+
+            _hookRetriever->InitFunctionsVmh->Read(0, sizeof(InitFunction) * initFunctions.size(), initFunctions.data());
+            _hookRetriever->HookFunctionsVmh->Read(0, sizeof(HookFunction) * hookFunctions.size(), hookFunctions.data());
+
+            DWORD prefferedImageBase = _peFile.PEHeader.OptionalHeader.ImageBase;
+            DWORD currentImageBase = reinterpret_cast<DWORD>(_debugger.ProcessDebugInfo.lpBaseOfImage);
+            DWORD imageBaseOffset = prefferedImageBase - currentImageBase;
+            if(imageBaseOffset != 0)
+                throw DynamicBaseUnsupportedException(reinterpret_cast<LPVOID>(prefferedImageBase), reinterpret_cast<LPVOID>(currentImageBase));
+
+            size_t initf = 0;
+            size_t thkIndex = 0;
+            for (size_t index = 0; index < _modules.size(); ++index)
+            {
+                Module& mdl = *std::next(_modules.begin(), index);
+                mdl.InitFunction = initFunctions[index];
+                if(mdl.InitFunction)
+                    initf++;
+
+                for (auto& hook : mdl.Hooks)
+                {
+                    hook.Placement = reinterpret_cast<Address>(reinterpret_cast<DWORD>(hook.Placement) + imageBaseOffset);
+
+                    HookFunction const func =  hookFunctions[thkIndex++];
+                    hook.Function = func;
+                }
+            }
+            _hookInjector = new HookInjector(_debugger, _modules);
+
+            DWORD processId = _debugger.ProcessInfo.dwProcessId;
+            _contextSharedMemoryName = "InjContext-" + std::to_string(processId);
+
+            spdlog::info("Inject context into shared memory (\"{}\")...", _contextSharedMemoryName);
+            _contextEmplacer = new ContextEmplacer(
+                _executableName.data(),
+                _arguments,
+                _contextSharedMemoryName.data(),
+                _debugger.Dlls    );
+            spdlog::info("Context injected.");
+
+            spdlog::info("Terminate loader thread...");
+            thread.Terminate(0);
+            spdlog::info("Process configured - resume main thread.");
+            _debugger.MainThread->Resume();
+        }
+
+        void OnAccessViolation(DebugLoop& dbgLoop, Thread& thread, Address address)
+        {
+            spdlog::critical("Access Violation at 0x{0:x} in thread {0:d}", (uint32_t) address, thread.Id);
+        }
+    };
 }
 #endif //INJECTOR_CONFIGURATOR_HPP

--- a/injector/context_emplacer.cpp
+++ b/injector/context_emplacer.cpp
@@ -2,84 +2,83 @@
 
 namespace Injector
 {
-	ContextEmplacer::ContextEmplacer(
-		string_view const& executableName,
-		string_view const& arguments,
-		string_view const& mapFileName,
-		map<LPVOID, DllInfo>& dlls)	:
-			Dlls(dlls),
-			ExecutableName(executableName),
-			Arguments(arguments),
-			SharedMemoryName(mapFileName)
-	{						
-		size_t maxNameLength = 0;
-		for (auto& pair : Dlls)
-		{
-			HMODULE const handle = static_cast<HMODULE>(pair.second.Base);				
-			string_view const& fn = pair.second.FileName;
-			maxNameLength = fn.length() > maxNameLength ? fn.length() : maxNameLength;					
-		}
-		
-		size_t const handlesSize = sizeof(HMODULE) * Dlls.size();
-		size_t const namesSize = sizeof(BYTE) * Dlls.size() * (maxNameLength + 1);
-		size_t const totalSize = 
-				sizeof(size_t)
-			+ sizeof(size_t)
-			+ ExecutableName.size() + 1
-			+ sizeof(size_t)
-			+ Arguments.size() + 1
-			+ sizeof(size_t)
-			+ sizeof(size_t)
-			+ handlesSize
-			+ namesSize;
+    ContextEmplacer::ContextEmplacer(
+        string_view const& executableName,
+        string_view const& arguments,
+        string_view const& mapFileName,
+        map<LPVOID, DllInfo>& dlls) :
+            Dlls(dlls),
+            ExecutableName(executableName),
+            Arguments(arguments),
+            SharedMemoryName(mapFileName)
+    {
+        size_t maxNameLength = 0;
+        for (auto& pair : Dlls)
+        {
+            HMODULE const handle = static_cast<HMODULE>(pair.second.Base);
+            string_view const& fn = pair.second.FileName;
+            maxNameLength = fn.length() > maxNameLength ? fn.length() : maxNameLength;
+        }
 
-		SharedMemory = CreateFileMapping(
-			INVALID_HANDLE_VALUE,
-			NULL,
-			PAGE_READWRITE,
-			0,
-			totalSize,
-			SharedMemoryName.data());
-		SharedMemoryPointer = static_cast<BYTE*>(MapViewOfFile(
-			SharedMemory,
-			FILE_MAP_ALL_ACCESS,
-			0, 0, totalSize));
-		
-		DataSize								= offset_ptr<size_t>(SharedMemoryPointer, 0);
-		ExecutableNameSize				= offset_ptr<size_t>(DataSize, sizeof(size_t));
-		ExecutableNameInStruct			= offset_ptr<char>(ExecutableNameSize, sizeof(size_t));
-		ArgumentsSize						= offset_ptr<size_t>(ExecutableNameInStruct, ExecutableName.size() + 1);
-		ArgumentsInStruct					= offset_ptr<char>(ArgumentsSize, sizeof(size_t));
-		NameLength							= offset_ptr<size_t>(ArgumentsInStruct, Arguments.size() + 1);
-		ModuleSize							= offset_ptr<size_t>(NameLength, sizeof(size_t));
-		Handles									= offset_ptr<HMODULE>(ModuleSize, sizeof(size_t));
-		Names									= offset_ptr<char>(Handles, handlesSize);
+        size_t const handlesSize = sizeof(HMODULE) * Dlls.size();
+        size_t const namesSize   = sizeof(BYTE)    * Dlls.size() * (maxNameLength + 1);
+        size_t const totalSize   = sizeof(size_t)
+                                 + sizeof(size_t)
+                                 + ExecutableName.size() + 1
+                                 + sizeof(size_t)
+                                 + Arguments.size() + 1
+                                 + sizeof(size_t)
+                                 + sizeof(size_t)
+                                 + handlesSize
+                                 + namesSize;
 
-		*DataSize								= totalSize;
-		*ExecutableNameSize				= ExecutableName.size();
-		memcpy(ExecutableNameInStruct, ExecutableName.data(), ExecutableName.size() + 1);
-		*ArgumentsSize						= Arguments.size();
-		memcpy(ArgumentsInStruct, Arguments.data(), Arguments.size() + 1);
-		*NameLength							= maxNameLength;
-		*ModuleSize							= Dlls.size();
-					
-		char* refName = reinterpret_cast<char*>(Names);
-		HMODULE* refHandle = Handles;
-		for (auto& pair : Dlls)
-		{
-			string_view const& name = pair.second.FileName;
-			memcpy(refName, name.data(), name.size() + 1);
+        SharedMemory = CreateFileMapping(
+            INVALID_HANDLE_VALUE,
+            NULL,
+            PAGE_READWRITE,
+            0,
+            totalSize,
+            SharedMemoryName.data());
+        SharedMemoryPointer = static_cast<BYTE*>(MapViewOfFile(
+            SharedMemory,
+            FILE_MAP_ALL_ACCESS,
+            0, 0, totalSize));
 
-			HMODULE const handle = static_cast<HMODULE>(pair.second.Base);
-			*refHandle = handle;
-			
-			refName += (maxNameLength + 1);
-			refHandle++;
-		}
-	}
-	ContextEmplacer::~ContextEmplacer()
-	{
-		UnmapViewOfFile(SharedMemoryPointer);
-		CloseHandle(SharedMemory);
-	}
+        DataSize               = offset_ptr<size_t>(SharedMemoryPointer, 0);
+        ExecutableNameSize     = offset_ptr<size_t>(DataSize, sizeof(size_t));
+        ExecutableNameInStruct = offset_ptr<char>(ExecutableNameSize, sizeof(size_t));
+        ArgumentsSize          = offset_ptr<size_t>(ExecutableNameInStruct, ExecutableName.size() + 1);
+        ArgumentsInStruct      = offset_ptr<char>(ArgumentsSize, sizeof(size_t));
+        NameLength             = offset_ptr<size_t>(ArgumentsInStruct, Arguments.size() + 1);
+        ModuleSize             = offset_ptr<size_t>(NameLength, sizeof(size_t));
+        Handles                = offset_ptr<HMODULE>(ModuleSize, sizeof(size_t));
+        Names                  = offset_ptr<char>(Handles, handlesSize);
+
+        *DataSize              = totalSize;
+        *ExecutableNameSize    = ExecutableName.size();
+        memcpy(ExecutableNameInStruct, ExecutableName.data(), ExecutableName.size() + 1);
+        *ArgumentsSize         = Arguments.size();
+        memcpy(ArgumentsInStruct, Arguments.data(), Arguments.size() + 1);
+        *NameLength            = maxNameLength;
+        *ModuleSize            = Dlls.size();
+                    
+        char* refName = reinterpret_cast<char*>(Names);
+        HMODULE* refHandle = Handles;
+        for (auto& pair : Dlls)
+        {
+            string_view const& name = pair.second.FileName;
+            memcpy(refName, name.data(), name.size() + 1);
+
+            HMODULE const handle = static_cast<HMODULE>(pair.second.Base);
+            *refHandle = handle;
+
+            refName += (maxNameLength + 1);
+            refHandle++;
+        }
+    }
+    ContextEmplacer::~ContextEmplacer()
+    {
+        UnmapViewOfFile(SharedMemoryPointer);
+        CloseHandle(SharedMemory);
+    }
 }

--- a/injector/context_emplacer.hpp
+++ b/injector/context_emplacer.hpp
@@ -11,35 +11,35 @@
 
 namespace Injector
 {
-	class ContextEmplacer final
-	{
-	private:
-	public:
-		DllMap&											Dlls;
+    class ContextEmplacer final
+    {
+    private:
+    public:
+        DllMap&            Dlls;
 
-		string_view const&							ExecutableName;
-		string_view const&							Arguments;
+        string_view const& ExecutableName;
+        string_view const& Arguments;
 
-		string											SharedMemoryName;
-		HANDLE											SharedMemory { nullptr };
-		BYTE*											SharedMemoryPointer { nullptr };
+        string             SharedMemoryName;
+        HANDLE             SharedMemory { nullptr };
+        BYTE*              SharedMemoryPointer { nullptr };
 
-		size_t*											DataSize;
-		size_t*											ExecutableNameSize;
-		char*											ExecutableNameInStruct;
-		size_t*											ArgumentsSize;
-		char*											ArgumentsInStruct;
-		size_t*											NameLength;
-		size_t*											ModuleSize;
-		HMODULE*									Handles;
-		char*											Names;
-		
-		ContextEmplacer(
-			string_view const& executableName,
-			string_view const& arguments,
-			string_view const& mapFileName,
-			map<LPVOID, DllInfo>& dlls);
-		~ContextEmplacer();
-	};
+        size_t*            DataSize;
+        size_t*            ExecutableNameSize;
+        char*              ExecutableNameInStruct;
+        size_t*            ArgumentsSize;
+        char*              ArgumentsInStruct;
+        size_t*            NameLength;
+        size_t*            ModuleSize;
+        HMODULE*           Handles;
+        char*              Names;
+
+        ContextEmplacer(
+            string_view const& executableName,
+            string_view const& arguments,
+            string_view const& mapFileName,
+            map<LPVOID, DllInfo>& dlls);
+        ~ContextEmplacer();
+    };
 }
 #endif //INJECTOR_CONTEXT_EMPLACER_HPP

--- a/injector/framework.hpp
+++ b/injector/framework.hpp
@@ -1,12 +1,6 @@
 ﻿#ifndef INJECTOR_FRAMEWORK_HPP
 #define INJECTOR_FRAMEWORK_HPP
 
-#include <handle.hpp>
-#include <macro.hpp>
-#include <events.hpp>
-#include <string.hpp>
-#include <portable_executable.hpp>
-
 #include <utility>
 #include <exception>
 #include <string_view>
@@ -17,6 +11,12 @@
 #include <vector>
 #include <memory>
 #include <variant>
+
+#include <handle.hpp>
+#include <macro.hpp>
+#include <events.hpp>
+#include <string.hpp>
+#include <portable_executable.hpp>
 
 //#define FMT_HEADER_ONLY
 #include <spdlog/spdlog.h>
@@ -29,22 +29,21 @@
 
 namespace Injector
 {
-	using std::exception;
-	using std::string;
-	using std::string_view;
-	using std::map;
-	using std::list;
-	using std::vector;
+    using std::exception;
+    using std::string;
+    using std::string_view;
+    using std::map;
+    using std::list;
+    using std::vector;
 
-	using std::unique_ptr;
-	using std::make_unique;
+    using std::unique_ptr;
+    using std::make_unique;
 }
 
 template<typename TFunction>
 inline TFunction GetFunctionAddress(HMODULE handle, std::string_view const& name)
 {
-	return reinterpret_cast<TFunction>(GetProcAddress(handle, name.data()));
+    return reinterpret_cast<TFunction>(GetProcAddress(handle, name.data()));
 }
-
 
 #endif //INJECTOR_FRAMEWORK_HPP

--- a/injector/get_function_code.hpp
+++ b/injector/get_function_code.hpp
@@ -8,122 +8,122 @@
 
 namespace Injector
 {
-	using PECOFF::GetProcAddressFunction;
+    using PECOFF::GetProcAddressFunction;
 
-	BYTE const GetProcAddressCodeData[] =
-	{
-		PUSH_INTO_STACK(INIT_PTR), // 0, 1-2-3-4 - pointer to procName,
-		PUSH_INTO_STACK(INIT_PTR), // 5, 6-7-8-9 - HMODULE (void*) , i.e. handle.
-		CALL_PTR32(INIT_PTR), // 10-11, 12-13-14-15 - pointer to imported in process GetProcAddress function.
-		MOV_EAX_TO(INIT_PTR), // 16, 17-18-19-20 - address for FARPROC (void*).
-	};
-	static constexpr size_t GetProcAddressCodeDataSize = sizeof(GetProcAddressCodeData);	
-	#pragma pack(push, 1)
-	struct GetProcAddressCode
-	{
-		BYTE arr1[1] { 0 };
-		LPCSTR ProcName = nullptr;
-		BYTE arr2[1] { 0 };
-		HMODULE Handle = nullptr;
-		BYTE arr3[2] { 0, 0 };
-		GetProcAddressFunction GetProcAddressFunc;
-		BYTE arr4[1] { 0 };
-		FARPROC* RefFunctionPointer;
-		//BYTE arr5[2] { 0, 0 };
+    BYTE const GetProcAddressCodeData[] =
+    {
+        PUSH_INTO_STACK(INIT_PTR), // 0, 1-2-3-4 - pointer to procName,
+        PUSH_INTO_STACK(INIT_PTR), // 5, 6-7-8-9 - HMODULE (void*) , i.e. handle.
+        CALL_PTR32(INIT_PTR),      // 10-11, 12-13-14-15 - pointer to imported in process GetProcAddress function.
+        MOV_EAX_TO(INIT_PTR),      // 16, 17-18-19-20 - address for FARPROC (void*).
+    };
+    static constexpr size_t GetProcAddressCodeDataSize = sizeof(GetProcAddressCodeData);
+    #pragma pack(push, 1)
+    struct GetProcAddressCode
+    {
+        BYTE arr1[1] { 0 };
+        LPCSTR ProcName = nullptr;
+        BYTE arr2[1] { 0 };
+        HMODULE Handle = nullptr;
+        BYTE arr3[2] { 0, 0 };
+        GetProcAddressFunction GetProcAddressFunc;
+        BYTE arr4[1] { 0 };
+        FARPROC* RefFunctionPointer;
+        //BYTE arr5[2] { 0, 0 };
 
-		GetProcAddressCode() noexcept = default;
-		GetProcAddressCode(
-			LPCSTR procName, HMODULE handle, 
-			GetProcAddressFunction gpaFunction,
-			FARPROC* refFunctionPointer)
-		{
-			memcpy(this, &GetProcAddressCodeData, GetProcAddressCodeDataSize);
-			ProcName = procName;
-			Handle = handle;
-			GetProcAddressFunc = gpaFunction;
-			RefFunctionPointer = refFunctionPointer;
-		}
-	};
-	static constexpr size_t GetProcAddressCodeSize = sizeof(GetProcAddressCode);
-	#pragma pack(pop)
-	static_assert(GetProcAddressCodeDataSize == GetProcAddressCodeSize, "The code and data are not equals");
-	
-	struct ProcNameOutOfRangeException : std::exception {};
-	
-	class GetFunctionCodeHandle final
-	{		
-		ProcessMemory& _processMemory;
-	
-		size_t _procNameLength = 0;
-		CHAR* _procNameBuffer = new CHAR[MaxProcNameLength + 1];
-		VirtualMemoryHandle& _procNameMemoryHandle;
-	
-		FARPROC _funcBuffer { nullptr };
-		VirtualMemoryHandle& _funcMemoryHandle;
-	
-		GetProcAddressCode _code;
-		VirtualMemoryHandle& _codeMemoryHandle;	
-	
-	public:
-		GetFunctionCodeHandle(
-			GetProcAddressFunction getProcAddressFunction, 
-			ProcessMemory& processMemory) :
-				_processMemory(processMemory),
-				_procNameMemoryHandle(processMemory.Allocate(MaxLibraryNameLength + 1)),
-				_funcMemoryHandle(processMemory.Allocate(sizeof(FARPROC))),
-				_codeMemoryHandle(processMemory.Allocate(GetProcAddressCodeDataSize)),
-				_code()
-		{			
-			memcpy(&_code, GetProcAddressCodeData, GetProcAddressCodeDataSize);
+        GetProcAddressCode() noexcept = default;
+        GetProcAddressCode(
+            LPCSTR procName, HMODULE handle, 
+            GetProcAddressFunction gpaFunction,
+            FARPROC* refFunctionPointer)
+        {
+            memcpy(this, &GetProcAddressCodeData, GetProcAddressCodeDataSize);
+            ProcName           = procName;
+            Handle             = handle;
+            GetProcAddressFunc = gpaFunction;
+            RefFunctionPointer = refFunctionPointer;
+        }
+    };
+    static constexpr size_t GetProcAddressCodeSize = sizeof(GetProcAddressCode);
+    #pragma pack(pop)
+    static_assert(GetProcAddressCodeDataSize == GetProcAddressCodeSize, "The code and data are not equals");
+    
+    struct ProcNameOutOfRangeException : std::exception {};
+    
+    class GetFunctionCodeHandle final
+    {
+        ProcessMemory& _processMemory;
+    
+        size_t _procNameLength = 0;
+        CHAR*  _procNameBuffer = new CHAR[MaxProcNameLength + 1];
+        VirtualMemoryHandle& _procNameMemoryHandle;
+    
+        FARPROC _funcBuffer { nullptr };
+        VirtualMemoryHandle& _funcMemoryHandle;
+    
+        GetProcAddressCode _code;
+        VirtualMemoryHandle& _codeMemoryHandle;    
+    
+    public:
+        GetFunctionCodeHandle(
+            GetProcAddressFunction getProcAddressFunction, 
+            ProcessMemory& processMemory) :
+                _processMemory(processMemory),
+                _procNameMemoryHandle(processMemory.Allocate(MaxLibraryNameLength + 1)),
+                _funcMemoryHandle(processMemory.Allocate(sizeof(FARPROC))),
+                _codeMemoryHandle(processMemory.Allocate(GetProcAddressCodeDataSize)),
+                _code()
+        {
+            memcpy(&_code, GetProcAddressCodeData, GetProcAddressCodeDataSize);
 
-			_code.ProcName = reinterpret_cast<cstring>(_procNameMemoryHandle.Pointer());
-			_code.GetProcAddressFunc = getProcAddressFunction;
-			_code.RefFunctionPointer = reinterpret_cast<FARPROC*>(_funcMemoryHandle.Pointer());
-	
-			_codeMemoryHandle.Write(&_code, GetProcAddressCodeDataSize, 0);
-		}
-		~GetFunctionCodeHandle()
-		{
-			_procNameLength = 0;
-	
-			delete[] _procNameBuffer;
-	
-			_processMemory.Free(_codeMemoryHandle);
-			_processMemory.Free(_procNameMemoryHandle);
-		}
-	
-		void SetProcName(string_view const& procName)
-		{
-			if (procName.size() > MaxLibraryNameLength)
-				throw ProcNameOutOfRangeException();
-			
-			_procNameMemoryHandle.Write(const_cast<char*>(procName.data()), procName.size() + 1, 0);
-	
-			_procNameLength = procName.size();
-		}
-		string_view const& ProcName() const
-		{
-			if (_procNameLength == 0)
-				return nullptr;
-	
-			_procNameMemoryHandle.Read(0, _procNameLength + 1, _procNameBuffer);
-			return _procNameBuffer;
-		}
-	
-		void SetHandle(HMODULE handle)
-		{
-			_code.Handle = handle;
-			_codeMemoryHandle.Write(&_code, GetProcAddressCodeDataSize, 0);
-		}	
-		HMODULE Handle() const	{	return _code.Handle;	}
-	
-		FARPROC Function() const
-		{	
-			_funcMemoryHandle.Read(0, sizeof(FARPROC), const_cast<FARPROC*>(&_funcBuffer));
-			return _funcBuffer;
-		}	
-	
-		Address Instruction() const { return _codeMemoryHandle.Pointer(); }
-	};	
+            _code.ProcName           = reinterpret_cast<cstring>(_procNameMemoryHandle.Pointer());
+            _code.GetProcAddressFunc = getProcAddressFunction;
+            _code.RefFunctionPointer = reinterpret_cast<FARPROC*>(_funcMemoryHandle.Pointer());
+    
+            _codeMemoryHandle.Write(&_code, GetProcAddressCodeDataSize, 0);
+        }
+        ~GetFunctionCodeHandle()
+        {
+            _procNameLength = 0;
+    
+            delete[] _procNameBuffer;
+    
+            _processMemory.Free(_codeMemoryHandle);
+            _processMemory.Free(_procNameMemoryHandle);
+        }
+    
+        void SetProcName(string_view const& procName)
+        {
+            if (procName.size() > MaxLibraryNameLength)
+                throw ProcNameOutOfRangeException();
+            
+            _procNameMemoryHandle.Write(const_cast<char*>(procName.data()), procName.size() + 1, 0);
+    
+            _procNameLength = procName.size();
+        }
+        string_view const& ProcName() const
+        {
+            if (_procNameLength == 0)
+                return nullptr;
+    
+            _procNameMemoryHandle.Read(0, _procNameLength + 1, _procNameBuffer);
+            return _procNameBuffer;
+        }
+    
+        void SetHandle(HMODULE handle)
+        {
+            _code.Handle = handle;
+            _codeMemoryHandle.Write(&_code, GetProcAddressCodeDataSize, 0);
+        }    
+        HMODULE Handle() const { return _code.Handle; }
+    
+        FARPROC Function() const
+        {    
+            _funcMemoryHandle.Read(0, sizeof(FARPROC), const_cast<FARPROC*>(&_funcBuffer));
+            return _funcBuffer;
+        }    
+    
+        Address Instruction() const { return _codeMemoryHandle.Pointer(); }
+    };    
 }
 #endif //INJECTOR_GET_FUNCTION_CODE_HPP

--- a/injector/hook.cpp
+++ b/injector/hook.cpp
@@ -2,25 +2,25 @@
 
 namespace Injector
 {
-	inline HookDecl decl(Address address, size_t size, Address functionNamePtr)
-	{
-		HookDecl h;
-		h.Address				= (DWORD) address;
-		h.Size					= size;
-		h.FunctionNamePtr	= (DWORD) functionNamePtr;
-		return h;
-	}
+    inline HookDecl decl(Address address, size_t size, Address functionNamePtr)
+    {
+        HookDecl h;
+        h.Address         = (DWORD) address;
+        h.Size            = size;
+        h.FunctionNamePtr = (DWORD) functionNamePtr;
+        return h;
+    }
 
-	Hook::Hook(std::string functionName, Address address, size_t size) 
-		: Hook(functionName, decl(address, size, nullptr)) {}
-	Hook::Hook(std::string functionName, HookDecl& decl) :
-		Type(HookType::Generic),
-		FunctionName(functionName),
-		Decl(decl)
-	{}
-	Hook::Hook(std::string functionName, ExtendedHookDecl& decl) :
-		Type(HookType::Extended),
-		FunctionName(functionName),
-		Decl(decl)
-	{}
+    Hook::Hook(std::string functionName, Address address, size_t size) 
+        : Hook(functionName, decl(address, size, nullptr)) {}
+    Hook::Hook(std::string functionName, HookDecl& decl) :
+        Type(HookType::Generic),
+        FunctionName(functionName),
+        Decl(decl)
+    {}
+    Hook::Hook(std::string functionName, ExtendedHookDecl& decl) :
+        Type(HookType::Extended),
+        FunctionName(functionName),
+        Decl(decl)
+    {}
 }

--- a/injector/hook.hpp
+++ b/injector/hook.hpp
@@ -5,37 +5,37 @@
 
 namespace Injector
 {
-	class Module;
-	enum class HookType
-	{
-		Unknown		= 0,
-		/* HookDecl */
-		Generic			= 1,
-		/* ExtendedHookDecl */
-		Extended		= 2,
-	};
-	class Hook final
-	{
-		friend class Module;
-	public:
-		using Variant = std::variant<HookDecl, ExtendedHookDecl>;
+    class Module;
+    enum class HookType
+    {
+        Unknown  = 0,
+        /* HookDecl */
+        Generic  = 1,
+        /* ExtendedHookDecl */
+        Extended = 2,
+    };
+    class Hook final
+    {
+        friend class Module;
+    public:
+        using Variant = std::variant<HookDecl, ExtendedHookDecl>;
 
-		HookType			const		Type						= HookType::Unknown;
-		Variant				const		Decl;
-		std::string			const		FunctionName;
+        HookType    const Type = HookType::Unknown;
+        Variant     const Decl;
+        std::string const FunctionName;
 
-		HookFunction					Function				{ nullptr };
-		Address							Placement				{ nullptr };
-		Address							ModuleBase			{ nullptr };
-		std::string						ModuleName			= "";
-		unsigned int					ModuleChecksum	= 0;
-		size_t							Size						= 0;
-	private:
-	public:
-		Hook(std::string functionName, Address address, size_t size);
-		Hook(std::string functionName, HookDecl& decl);
-		Hook(std::string functionName, ExtendedHookDecl& decl);
-	};
+        HookFunction Function       { nullptr };
+        Address      Placement      { nullptr };
+        Address      ModuleBase     { nullptr };
+        std::string  ModuleName     = "";
+        unsigned int ModuleChecksum = 0;
+        size_t       Size           = 0;
+    private:
+    public:
+        Hook(std::string functionName, Address address, size_t size);
+        Hook(std::string functionName, HookDecl& decl);
+        Hook(std::string functionName, ExtendedHookDecl& decl);
+    };
 }
 
 #endif //INJECTOR_HOOK_HPP

--- a/injector/hook_injector.cpp
+++ b/injector/hook_injector.cpp
@@ -2,233 +2,233 @@
 
 namespace Injector
 {
-	HookInjector::HookInjector(Debugger::DebugLoop& dbgr, list<Module>& modules)	
-			: Memory(dbgr.Memory), Modules(modules)
-	{			
-		auto executableChecksum = CRC32::compute_stream(file_open_binary(dbgr.ExecutablePath));
-		for (Module& mdl : modules)
-		{
-			HMODULE handle = mdl.get_handle();
+    HookInjector::HookInjector(Debugger::DebugLoop& dbgr, list<Module>& modules)    
+            : Memory(dbgr.Memory), Modules(modules)
+    {
+        auto executableChecksum = CRC32::compute_stream(file_open_binary(dbgr.ExecutablePath));
+        for (Module& mdl : modules)
+        {
+            HMODULE handle = mdl.get_handle();
 
-			if (!handle)
-			{
-				spdlog::warn("Module \"{0}\" handle is null, skip. -Please sure that it loads correctly.", mdl.FileName);
-				continue;
-			}
-			spdlog::info("Module: \"{0}\" [0x{1:x}] now processing hooks:", mdl.FileName, (uint32_t) handle);
-			
-			for (auto& hook : mdl.Hooks)
-			{					
-				if (!hook.Function)
-				{
-					spdlog::warn("::Hook \"{0}\" function not found, skip. -Please, sure that hooks were scanned correctly.", hook.FunctionName);
-					continue;
-				}
+            if (!handle)
+            {
+                spdlog::warn("Module \"{0}\" handle is null, skip. -Please sure that it loads correctly.", mdl.FileName);
+                continue;
+            }
+            spdlog::info("Module: \"{0}\" [0x{1:x}] now processing hooks:", mdl.FileName, (uint32_t) handle);
+            
+            for (auto& hook : mdl.Hooks)
+            {
+                if (!hook.Function)
+                {
+                    spdlog::warn("::Hook \"{0}\" function not found, skip. -Please, sure that hooks were scanned correctly.", hook.FunctionName);
+                    continue;
+                }
 
-				auto checksum				= executableChecksum;
-				auto placement				= hook.Placement;
-				if (!hook.ModuleName.empty())
-				{
-					auto iter = std::find_if(dbgr.Dlls.cbegin(), dbgr.Dlls.cend(), 
-						[&hook, &dbgr](DllMap::value_type pair) -> bool
-						{
-							auto ofnp		= std::filesystem::path(pair.second.FVI.Loaded ? pair.second.FVI.OriginalFilename : pair.second.FileName);
-							auto ofn			= ofnp.filename(); // .stem(); no extension
-							auto mfnp		= std::filesystem::path(hook.ModuleName);
-							auto mfn		= mfnp.filename(); //.stem();
-							return ofn == mfn;
-						}
-					);
-					if (iter == dbgr.Dlls.cend())
-					{
-						spdlog::info("::Hook \"{0}\" target module \"{1}\" not found, skip.", 
-							hook.FunctionName,
-							hook.ModuleName
-						); continue;
-					}
+                auto checksum  = executableChecksum;
+                auto placement = hook.Placement;
+                if (!hook.ModuleName.empty())
+                {
+                    auto iter = std::find_if(dbgr.Dlls.cbegin(), dbgr.Dlls.cend(), 
+                        [&hook, &dbgr](DllMap::value_type pair) -> bool
+                        {
+                            auto ofnp = std::filesystem::path(pair.second.FVI.Loaded ? pair.second.FVI.OriginalFilename : pair.second.FileName);
+                            auto ofn  = ofnp.filename(); // .stem(); no extension
+                            auto mfnp = std::filesystem::path(hook.ModuleName);
+                            auto mfn  = mfnp.filename(); //.stem();
+                            return ofn == mfn;
+                        }
+                    );
+                    if (iter == dbgr.Dlls.cend())
+                    {
+                        spdlog::info("::Hook \"{0}\" target module \"{1}\" not found, skip.", 
+                            hook.FunctionName,
+                            hook.ModuleName
+                        ); continue;
+                    }
 
-					hook.ModuleBase	= iter->first;
-					placement				= reinterpret_cast<Address>(reinterpret_cast<DWORD>(placement) + reinterpret_cast<DWORD>(hook.ModuleBase));
-					checksum				= iter->second.Checksum;
-				}
+                    hook.ModuleBase = iter->first;
+                    placement       = reinterpret_cast<Address>(reinterpret_cast<DWORD>(placement) + reinterpret_cast<DWORD>(hook.ModuleBase));
+                    checksum        = iter->second.Checksum;
+                }
 
-				if (hook.ModuleChecksum == 0 || checksum == hook.ModuleChecksum)
-				{
-					if (!hook.ModuleName.empty())
-						spdlog::info("::[0x{2:x}:0x{3:x} = 0x{4:x}] - on \"{1}\" placed hook \"{0}\".",
-							hook.FunctionName, hook.ModuleName,
-							(uint32_t) hook.ModuleBase, (uint32_t) hook.Placement, (uint32_t) placement
-						);
-					else
-						spdlog::info("::[0x{2:x}:0x{3:x} = 0x{4:x}] - on executable placed hook \"{0}\".",
-							hook.FunctionName, hook.ModuleName,
-							(uint32_t) hook.ModuleBase, (uint32_t) hook.Placement, (uint32_t) placement
-						);
-				}
-				else
-				{
-					spdlog::info("::Hook \"{0}\": module checksum [0x{1:x}] and required [0x{2:x}] are different, skip.",
-						hook.FunctionName, checksum, hook.ModuleChecksum
-					);
-					continue;
-				}
+                if (hook.ModuleChecksum == 0 || checksum == hook.ModuleChecksum)
+                {
+                    if (!hook.ModuleName.empty())
+                        spdlog::info("::[0x{2:x}:0x{3:x} = 0x{4:x}] - on \"{1}\" placed hook \"{0}\".",
+                            hook.FunctionName, hook.ModuleName,
+                            (uint32_t) hook.ModuleBase, (uint32_t) hook.Placement, (uint32_t) placement
+                        );
+                    else
+                        spdlog::info("::[0x{2:x}:0x{3:x} = 0x{4:x}] - on executable placed hook \"{0}\".",
+                            hook.FunctionName, hook.ModuleName,
+                            (uint32_t) hook.ModuleBase, (uint32_t) hook.Placement, (uint32_t) placement
+                        );
+                }
+                else
+                {
+                    spdlog::info("::Hook \"{0}\": module checksum [0x{1:x}] and required [0x{2:x}] are different, skip.",
+                        hook.FunctionName, checksum, hook.ModuleChecksum
+                    );
+                    continue;
+                }
 
-				auto pocketIterator = Pockets.find(placement);
-				if(pocketIterator == Pockets.end())
-					pocketIterator = Pockets.emplace(placement, HookPocket()).first;
+                auto pocketIterator = Pockets.find(placement);
+                if(pocketIterator == Pockets.end())
+                    pocketIterator = Pockets.emplace(placement, HookPocket()).first;
 
-				HookPocket& pocket = pocketIterator->second;
-				pocket.Hooks.push_back(&hook);
-				pocket.OverriddenCount = 
-					hook.Size > pocket.OverriddenCount ? hook.Size : pocket.OverriddenCount;
-			}
-		}
+                HookPocket& pocket = pocketIterator->second;
+                pocket.Hooks.push_back(&hook);
+                pocket.OverriddenCount = 
+                    hook.Size > pocket.OverriddenCount ? hook.Size : pocket.OverriddenCount;
+            }
+        }
 
-		size_t programSize = 0;
+        size_t programSize = 0;
 
-		spdlog::info("Iterate hook pockets and calculate total program size...");
-		for (auto& pair : Pockets)
-		{
-			HookPocket& pocket = pair.second;
-						
-			size_t const overridenCount = pocket.OverriddenCount;
-			if (overridenCount < 5)
-				pocket.OverriddenCount = 5;
+        spdlog::info("Iterate hook pockets and calculate total program size...");
+        for (auto& pair : Pockets)
+        {
+            HookPocket& pocket = pair.second;
+                        
+            size_t const overridenCount = pocket.OverriddenCount;
+            if (overridenCount < 5)
+                pocket.OverriddenCount = 5;
 
-			pocket.OriginalBytes.resize(pocket.OverriddenCount);
-			Memory.Read(pair.first, pocket.OriginalBytes.data(), pocket.OriginalBytes.size());
-			if (auto rji = is_relative_jump(pocket.OriginalBytes))
-				programSize += 4; // byte jump - 2 bytes, int32 jump - 5 (but some 6) bytes. For edge case, when need extend every 1-byte jump to 4 byte-jump need +4 byte to total program size.
+            pocket.OriginalBytes.resize(pocket.OverriddenCount);
+            Memory.Read(pair.first, pocket.OriginalBytes.data(), pocket.OriginalBytes.size());
+            if (auto rji = is_relative_jump(pocket.OriginalBytes))
+                programSize += 4; // byte jump - 2 bytes, int32 jump - 5 (but some 6) bytes. For edge case, when need extend every 1-byte jump to 4 byte-jump need +4 byte to total program size.
 
-			programSize += RegistersBuildCodeSize;
-			programSize += HookCallCodeSize * pocket.Hooks.size();
-			programSize += RegistersCleanupCodeSize;
-			programSize += pocket.OverriddenCount;
-			programSize += JumpCodeSize;
+            programSize += RegistersBuildCodeSize;
+            programSize += HookCallCodeSize * pocket.Hooks.size();
+            programSize += RegistersCleanupCodeSize;
+            programSize += pocket.OverriddenCount;
+            programSize += JumpCodeSize;
 
-			if (overridenCount < 5)
-				spdlog::trace("::[0x{0:x}] {1:d} fuctions, {2:d} overriden bytes (fixed from {3:d})", (uint32_t)pair.first, pair.second.Hooks.size(), pair.second.OverriddenCount, overridenCount);
-			else
-				spdlog::trace("::[0x{0:x}] {1:d} fuctions, {2:d} overriden bytes", (uint32_t)pair.first, pair.second.Hooks.size(), pair.second.OverriddenCount);
-		}
+            if (overridenCount < 5)
+                spdlog::trace("::[0x{0:x}] {1:d} fuctions, {2:d} overriden bytes (fixed from {3:d})", (uint32_t)pair.first, pair.second.Hooks.size(), pair.second.OverriddenCount, overridenCount);
+            else
+                spdlog::trace("::[0x{0:x}] {1:d} fuctions, {2:d} overriden bytes", (uint32_t)pair.first, pair.second.Hooks.size(), pair.second.OverriddenCount);
+        }
 
-		NextInstructionsVmh = &Memory.Allocate(sizeof(Address) * Pockets.size());
-		ProgramVmh = &Memory.Allocate(programSize);
+        NextInstructionsVmh = &Memory.Allocate(sizeof(Address) * Pockets.size());
+        ProgramVmh = &Memory.Allocate(programSize);
 
-		spdlog::info("Hook program block: ");
-		spdlog::info("::Address = 0x{0:x}", (uint32_t) ProgramVmh->Pointer(0));
-		spdlog::info("::Size = {0} (bytes)", ProgramVmh->Size());
-		spdlog::info("Next instruction memory block: ");
-		spdlog::info("::Address = 0x{0:x}", (uint32_t)NextInstructionsVmh->Pointer(0));
-		spdlog::info("::Size = {0} (bytes)", NextInstructionsVmh->Size());
+        spdlog::info("Hook program block: ");
+        spdlog::info("::Address = 0x{0:x}", (uint32_t) ProgramVmh->Pointer(0));
+        spdlog::info("::Size = {0} (bytes)", ProgramVmh->Size());
+        spdlog::info("Next instruction memory block: ");
+        spdlog::info("::Address = 0x{0:x}", (uint32_t)NextInstructionsVmh->Pointer(0));
+        spdlog::info("::Size = {0} (bytes)", NextInstructionsVmh->Size());
 
-		DWORD refNextInstruction = reinterpret_cast<DWORD>(NextInstructionsVmh->Pointer(0));
-		size_t offset = 0;
-		
-		spdlog::info("Hook program block assembling...");
-		for (auto& pair : Pockets)
-		{				
-			Address const hookAddr = pair.first;
-			HookPocket& pocket = pair.second;
-			pocket.Offset = offset;
+        DWORD refNextInstruction = reinterpret_cast<DWORD>(NextInstructionsVmh->Pointer(0));
+        size_t offset = 0;
+        
+        spdlog::info("Hook program block assembling...");
+        for (auto& pair : Pockets)
+        {                
+            Address const hookAddr = pair.first;
+            HookPocket& pocket = pair.second;
+            pocket.Offset = offset;
 
-			Address const jumpBase = reinterpret_cast<BYTE*>(hookAddr) + JumpR32lInstructionLength;
-			Address const jumpOffset = ProgramVmh->Pointer(offset);
-			
-			pocket.HookCallerBlockCode.Offset = relative_offset(jumpBase, jumpOffset);
-			Memory.Write(hookAddr, &pocket.HookCallerBlockCode, JumpCodeSize);
-			
-			pocket.RegistersBuild.HookAddress = hookAddr;
-			for (Hook* hook : pocket.Hooks)				
-			{
-				Address const base = ProgramVmh->Pointer(offset);
-				pocket.HookCallBlocks.emplace_back(
-					reinterpret_cast<Address>(refNextInstruction),
-					base,
-					hook->Function,
-					hook->ModuleBase);
-				offset += HookCallCodeSize;
-			}
-			offset = pocket.Offset;
+            Address const jumpBase   = reinterpret_cast<BYTE*>(hookAddr) + JumpR32lInstructionLength;
+            Address const jumpOffset = ProgramVmh->Pointer(offset);
+            
+            pocket.HookCallerBlockCode.Offset = relative_offset(jumpBase, jumpOffset);
+            Memory.Write(hookAddr, &pocket.HookCallerBlockCode, JumpCodeSize);
+            
+            pocket.RegistersBuild.HookAddress = hookAddr;
+            for (Hook* hook : pocket.Hooks)                
+            {
+                Address const base = ProgramVmh->Pointer(offset);
+                pocket.HookCallBlocks.emplace_back(
+                    reinterpret_cast<Address>(refNextInstruction),
+                    base,
+                    hook->Function,
+                    hook->ModuleBase);
+                offset += HookCallCodeSize;
+            }
+            offset = pocket.Offset;
 
-			size_t const hookCallersSize = pocket.HookCallBlocks.size() * HookCallCodeSize;
-			size_t const overridenSize = pocket.OriginalBytes.size();
-			size_t const jumpBackSize = JumpCodeSize;
+            size_t const hookCallersSize = pocket.HookCallBlocks.size() * HookCallCodeSize;
+            size_t const overridenSize = pocket.OriginalBytes.size();
+            size_t const jumpBackSize = JumpCodeSize;
 
-			ProgramVmh->Write(&pocket.RegistersBuild, RegistersBuildCodeSize, offset);
-			offset += RegistersBuildCodeSize;
+            ProgramVmh->Write(&pocket.RegistersBuild, RegistersBuildCodeSize, offset);
+            offset += RegistersBuildCodeSize;
 
-			ProgramVmh->Write(pocket.HookCallBlocks.data(), hookCallersSize, offset);
-			offset += hookCallersSize;
+            ProgramVmh->Write(pocket.HookCallBlocks.data(), hookCallersSize, offset);
+            offset += hookCallersSize;
 
-			ProgramVmh->Write(&pocket.RegistersCleanup, RegistersCleanupCodeSize, offset);
-			offset += RegistersCleanupCodeSize;
+            ProgramVmh->Write(&pocket.RegistersCleanup, RegistersCleanupCodeSize, offset);
+            offset += RegistersCleanupCodeSize;
 
-			if (auto rji = is_relative_jump(pocket.OriginalBytes))
-			{
-				Address		pFrom		= ProgramVmh->Pointer(offset);
-				auto			oldOffset	= get_relative_offset(pocket.OriginalBytes, rji);
-				auto			pTo			= restore_address(hookAddr, oldOffset, rji.Cmd.Command.size());
-				try
-				{
-					auto newOffset		= relative_offset(pFrom, pTo, rji.Cmd.Command.size());
-					set_relative_offset(pocket.OriginalBytes, rji, newOffset);
+            if (auto rji = is_relative_jump(pocket.OriginalBytes))
+            {
+                Address pFrom     = ProgramVmh->Pointer(offset);
+                auto    oldOffset = get_relative_offset(pocket.OriginalBytes, rji);
+                auto    pTo       = restore_address(hookAddr, oldOffset, rji.Cmd.Command.size());
+                try
+                {
+                    auto newOffset = relative_offset(pFrom, pTo, rji.Cmd.Command.size());
+                    set_relative_offset(pocket.OriginalBytes, rji, newOffset);
 
-					spdlog::info("::{0} rel{1:d} => 0x{2:x}: 0x{3:x}+0x{4:x}:{5:X}h -> 0x{3:x}+0x{6:x}:{7:X}h)",
-						rji.Cmd.Mnemonic, rji.Cmd.Size * 8, (uint32_t) pTo,
-						rji.Cmd.Command.size(),
-						(uint32_t)	hookAddr, oldOffset,
-						(uint32_t)	pFrom , newOffset
-					);
-				}
-				catch (const invalid_jump_offset_error& ex)
-				{
-					try
-					{
-						auto		cmd		= find_rel_cmd(rji.Cmd.Mnemonic, 4);
-						std::vector<BYTE> extended; extended.resize(pocket.OriginalBytes.size() - rji.Cmd.Command.size() + cmd.Command.size());
-						memcpy(extended.data(), cmd.Command.data(), cmd.Command.size());
-						memcpy(extended.data() + cmd.Command.size(), pocket.OriginalBytes.data() + rji.Cmd.Command.size(), pocket.OriginalBytes.size() - rji.Cmd.Command.size());
-						auto newOffset	= relative_offset(pFrom, pTo, cmd.Command.size());
-						set_relative_offset(extended, rji, newOffset);
+                    spdlog::info("::{0} rel{1:d} => 0x{2:x}: 0x{3:x}+0x{4:x}:{5:X}h -> 0x{3:x}+0x{6:x}:{7:X}h)",
+                        rji.Cmd.Mnemonic, rji.Cmd.Size * 8, (uint32_t) pTo,
+                        rji.Cmd.Command.size(),
+                        (uint32_t) hookAddr, oldOffset,
+                        (uint32_t) pFrom , newOffset
+                    );
+                }
+                catch (const invalid_jump_offset_error& ex)
+                {
+                    try
+                    {
+                        auto cmd = find_rel_cmd(rji.Cmd.Mnemonic, 4);
+                        std::vector<BYTE> extended; extended.resize(pocket.OriginalBytes.size() - rji.Cmd.Command.size() + cmd.Command.size());
+                        memcpy(extended.data(), cmd.Command.data(), cmd.Command.size());
+                        memcpy(extended.data() + cmd.Command.size(), pocket.OriginalBytes.data() + rji.Cmd.Command.size(), pocket.OriginalBytes.size() - rji.Cmd.Command.size());
+                        auto newOffset = relative_offset(pFrom, pTo, cmd.Command.size());
+                        set_relative_offset(extended, rji, newOffset);
 
-						pocket.OriginalBytes = extended;
-						spdlog::info("::{0} rel{1:d} => 0x{2:x}: 0x{3:x}+0x{4:x}:{5:X}h -> 0x{3:x}+0x{6:x}:{7:X}h) - extended to {0} rel{8:d}",
-							rji.Cmd.Mnemonic, rji.Cmd.Size * 8, (uint32_t) pTo,
-							rji.Cmd.Command.size(),
-							(uint32_t)	hookAddr, oldOffset,
-							(uint32_t)	pFrom , newOffset,
-							cmd.Size * 8
-						);
-					}
-					catch (...)
-					{
-						spdlog::error("::{0} rel{1:d} => 0x{2:x}: 0x{3:x}+0x{4:x}:{5:X}h -> 0x{3:x}+0x{6:x}:{7:X}h) - no command with huge offset size, SKIP",
-							rji.Cmd.Mnemonic, rji.Cmd.Size * 8, (uint32_t) pTo,
-							rji.Cmd.Command.size(),
-							(uint32_t) hookAddr, oldOffset,
-							(uint32_t) pFrom, ex.Value
-						);
-					}
-				}
-			}
-			ProgramVmh->Write(pocket.OriginalBytes.data(), pocket.OriginalBytes.size(), offset);
-			offset += pocket.OriginalBytes.size();
+                        pocket.OriginalBytes = extended;
+                        spdlog::info("::{0} rel{1:d} => 0x{2:x}: 0x{3:x}+0x{4:x}:{5:X}h -> 0x{3:x}+0x{6:x}:{7:X}h) - extended to {0} rel{8:d}",
+                            rji.Cmd.Mnemonic, rji.Cmd.Size * 8, (uint32_t) pTo,
+                            rji.Cmd.Command.size(),
+                            (uint32_t) hookAddr, oldOffset,
+                            (uint32_t) pFrom , newOffset,
+                            cmd.Size * 8
+                        );
+                    }
+                    catch (...)
+                    {
+                        spdlog::error("::{0} rel{1:d} => 0x{2:x}: 0x{3:x}+0x{4:x}:{5:X}h -> 0x{3:x}+0x{6:x}:{7:X}h) - no command with huge offset size, SKIP",
+                            rji.Cmd.Mnemonic, rji.Cmd.Size * 8, (uint32_t) pTo,
+                            rji.Cmd.Command.size(),
+                            (uint32_t) hookAddr, oldOffset,
+                            (uint32_t) pFrom, ex.Value
+                        );
+                    }
+                }
+            }
+            ProgramVmh->Write(pocket.OriginalBytes.data(), pocket.OriginalBytes.size(), offset);
+            offset += pocket.OriginalBytes.size();
 
-			// Jump back				
-			Address const jumpBackBase = ProgramVmh->Pointer(offset);
-			Address const jumpBackAddress = reinterpret_cast<BYTE*>(hookAddr) + max(JumpR32lInstructionLength, pocket.OverriddenCount);
-			pocket.JumpBackCode.Offset = relative_offset(jumpBackBase, jumpBackAddress, JumpR32lInstructionLength);
-			
-			ProgramVmh->Write(&pocket.JumpBackCode, jumpBackSize, offset);
-			offset += jumpBackSize;
-			
-			refNextInstruction++;
-		}			
-	}
-	HookInjector::~HookInjector()
-	{
-		Memory.Free(*NextInstructionsVmh);
-		Memory.Free(*ProgramVmh);
-	}
+            // Jump back
+            Address const jumpBackBase = ProgramVmh->Pointer(offset);
+            Address const jumpBackAddress = reinterpret_cast<BYTE*>(hookAddr) + max(JumpR32lInstructionLength, pocket.OverriddenCount);
+            pocket.JumpBackCode.Offset = relative_offset(jumpBackBase, jumpBackAddress, JumpR32lInstructionLength);
+            
+            ProgramVmh->Write(&pocket.JumpBackCode, jumpBackSize, offset);
+            offset += jumpBackSize;
+            
+            refNextInstruction++;
+        }
+    }
+    HookInjector::~HookInjector()
+    {
+        Memory.Free(*NextInstructionsVmh);
+        Memory.Free(*ProgramVmh);
+    }
 }

--- a/injector/hook_injector.hpp
+++ b/injector/hook_injector.hpp
@@ -11,158 +11,158 @@
 #include "get_function_code.hpp"
 
 namespace Injector
-{	
-	BYTE const RegistersBuildCodeData[] =
-	{
-		PUSHAD, PUSHFD,												// It creates REGISTERS structure
-		PUSH_INTO_STACK(INIT_DWORD),						// Push address of hook
-		PUSH_ESP,														// At the top of stack will be REGISTER, and it pushes this* for it
-	};
-	static constexpr size_t RegistersBuildCodeDataSize = sizeof(RegistersBuildCodeData);
+{
+    BYTE const RegistersBuildCodeData[] =
+    {
+        PUSHAD, PUSHFD,              // It creates REGISTERS structure
+        PUSH_INTO_STACK(INIT_DWORD), // Push address of hook
+        PUSH_ESP,                    // At the top of stack will be REGISTER, and it pushes this* for it
+    };
+    static constexpr size_t RegistersBuildCodeDataSize = sizeof(RegistersBuildCodeData);
 
-	#pragma pack(push, 1)
-	struct RegistersBuildCode
-	{
-		BYTE Pushad;
-		BYTE Pushfd;
-		BYTE PUSH_MEM_OpCode;
-		Address HookAddress;
-		BYTE PUSH_ESP_OpCode;
+    #pragma pack(push, 1)
+    struct RegistersBuildCode
+    {
+        BYTE Pushad;
+        BYTE Pushfd;
+        BYTE PUSH_MEM_OpCode;
+        Address HookAddress;
+        BYTE PUSH_ESP_OpCode;
 
-		RegistersBuildCode()
-		{
-			memcpy(this, RegistersBuildCodeData, RegistersBuildCodeDataSize);
-		}
-		RegistersBuildCode(Address hookAddress)
-		{
-			memcpy(this, RegistersBuildCodeData, RegistersBuildCodeDataSize);
+        RegistersBuildCode()
+        {
+            memcpy(this, RegistersBuildCodeData, RegistersBuildCodeDataSize);
+        }
+        RegistersBuildCode(Address hookAddress)
+        {
+            memcpy(this, RegistersBuildCodeData, RegistersBuildCodeDataSize);
 
-			HookAddress = hookAddress;
-		}
-	};
-	static constexpr size_t RegistersBuildCodeSize = sizeof(RegistersBuildCode);
-	#pragma pack(pop)
-	static_assert(RegistersBuildCodeSize == RegistersBuildCodeDataSize, "The code and data are not equals");
+            HookAddress = hookAddress;
+        }
+    };
+    static constexpr size_t RegistersBuildCodeSize = sizeof(RegistersBuildCode);
+    #pragma pack(pop)
+    static_assert(RegistersBuildCodeSize == RegistersBuildCodeDataSize, "The code and data are not equals");
 
-	BYTE const RegistersCleanupCodeData[] =
-	{
-		ADD_ESP(0x08),												// Remove REGISTERS* from stack
-		POPFD, POPAD													// Clear registers content from stack
-	};
-	static constexpr size_t RegistersCleanupCodeDataSize = sizeof(RegistersCleanupCodeData);
+    BYTE const RegistersCleanupCodeData[] =
+    {
+        ADD_ESP(0x08), // Remove REGISTERS* from stack
+        POPFD, POPAD   // Clear registers content from stack
+    };
+    static constexpr size_t RegistersCleanupCodeDataSize = sizeof(RegistersCleanupCodeData);
 
-	#pragma pack(push, 1)
-	struct RegistersCleanupCode
-	{
-		BYTE AddEsp[2];
-		BYTE AddEsp_Value;
-		BYTE Popfd;
-		BYTE PopAd;
+    #pragma pack(push, 1)
+    struct RegistersCleanupCode
+    {
+        BYTE AddEsp[2];
+        BYTE AddEsp_Value;
+        BYTE Popfd;
+        BYTE PopAd;
 
-		RegistersCleanupCode()
-		{
-			memcpy(this, RegistersCleanupCodeData, RegistersCleanupCodeDataSize);
-		}
-	};
-	static constexpr size_t RegistersCleanupCodeSize = sizeof(RegistersCleanupCode);
-	#pragma pack(pop)
-	static_assert(RegistersCleanupCodeSize == RegistersCleanupCodeDataSize, "The code and data are not equals");
+        RegistersCleanupCode()
+        {
+            memcpy(this, RegistersCleanupCodeData, RegistersCleanupCodeDataSize);
+        }
+    };
+    static constexpr size_t RegistersCleanupCodeSize = sizeof(RegistersCleanupCode);
+    #pragma pack(pop)
+    static_assert(RegistersCleanupCodeSize == RegistersCleanupCodeDataSize, "The code and data are not equals");
 
-	BYTE const HookCallCodeData[] =
-	{
-		CALL_R32(INIT_PTR),											// Invoke Hook function
-		MOV_EAX_TO(INIT_PTR),									// Save result of hook function, ds:ReturnEIP
-		CMP_PTR32_IMM32(INIT_PTR, 0x00),					// Test result for zero (it is address)  | CMP ds:ReturnEIP, 0
-		JZ_R8(0x15),														// Jump the next instruction outse hook caller (there must be placed overriden bytes with jumb back or another hook caller block
-		ADD_PTR32_IMM32(INIT_PTR, INIT_DWORD),		// Make correction of base for hook module. For executable itself it must be 0. | add dword ptr[ds:ReturnEIP], MODULE BASE (Handle)
-		ADD_ESP(0x08),												// Remove REGISTERS* from stack
-		POPFD, POPAD,													// Clear registers content from stack
-		JMP_PTR32(INIT_PTR),										// Jump to returned address | JMP ds:ReturnEIP
-	};
-	static constexpr size_t HookCallCodeDataSize = sizeof(HookCallCodeData);
-	static constexpr size_t HookCallCodeCallOffset = 8;
+    BYTE const HookCallCodeData[] =
+    {
+        CALL_R32(INIT_PTR),                    // Invoke Hook function
+        MOV_EAX_TO(INIT_PTR),                  // Save result of hook function, ds:ReturnEIP
+        CMP_PTR32_IMM32(INIT_PTR, 0x00),       // Test result for zero (it is address)  | CMP ds:ReturnEIP, 0
+        JZ_R8(0x15),                           // Jump the next instruction outse hook caller (there must be placed overriden bytes with jumb back or another hook caller block
+        ADD_PTR32_IMM32(INIT_PTR, INIT_DWORD), // Make correction of base for hook module. For executable itself it must be 0. | add dword ptr[ds:ReturnEIP], MODULE BASE (Handle)
+        ADD_ESP(0x08),                         // Remove REGISTERS* from stack
+        POPFD, POPAD,                          // Clear registers content from stack
+        JMP_PTR32(INIT_PTR),                   // Jump to returned address | JMP ds:ReturnEIP
+    };
+    static constexpr size_t HookCallCodeDataSize = sizeof(HookCallCodeData);
+    static constexpr size_t HookCallCodeCallOffset = 8;
 
-	#pragma pack(push, 1)
-	struct HookCallCode
-	{
-		BYTE CALL_OpCode;
-		DWORD FunctionProcRelativeAddress;
-		BYTE MOV_EAX_OpCode;
-		Address RefNextInstruction1;
-		BYTE CMP_ReturnEIP_OpCode_1;
-		BYTE CMP_ReturnEIP_OpCode_2;
-		Address RefNextInstruction2;
-		BYTE NULL_VALUE;
-		BYTE JZ_OpCode_1;
-		BYTE JZ_OpCode_2;
-		BYTE ADD_PTR32_IMM32_0[2];
-		Address RefNextInstruction3;
-		DWORD ModuleBase;
-		BYTE ADD_ESP_1_OpCode;
-		BYTE ADD_ESP_2_OpCode;
-		BYTE ADD_ESP_3_OpCode;
-		BYTE POP_FD_OpCode;
-		BYTE POP_AD_OpCode;
-		BYTE JMP_ReturnEip_OpCode_1;
-		BYTE JMP_ReturnEip_OpCode_2;
-		Address RefNextInstruction4;
+    #pragma pack(push, 1)
+    struct HookCallCode
+    {
+        BYTE    CALL_OpCode;
+        DWORD   FunctionProcRelativeAddress;
+        BYTE    MOV_EAX_OpCode;
+        Address RefNextInstruction1;
+        BYTE    CMP_ReturnEIP_OpCode_1;
+        BYTE    CMP_ReturnEIP_OpCode_2;
+        Address RefNextInstruction2;
+        BYTE    NULL_VALUE;
+        BYTE    JZ_OpCode_1;
+        BYTE    JZ_OpCode_2;
+        BYTE    ADD_PTR32_IMM32_0[2];
+        Address RefNextInstruction3;
+        DWORD   ModuleBase;
+        BYTE    ADD_ESP_1_OpCode;
+        BYTE    ADD_ESP_2_OpCode;
+        BYTE    ADD_ESP_3_OpCode;
+        BYTE    POP_FD_OpCode;
+        BYTE    POP_AD_OpCode;
+        BYTE    JMP_ReturnEip_OpCode_1;
+        BYTE    JMP_ReturnEip_OpCode_2;
+        Address RefNextInstruction4;
 
-		HookCallCode()
-		{
-			memcpy(this, HookCallCodeData, HookCallCodeDataSize);
-		}
-		HookCallCode(
-			Address refNextInstruction,
-			Address base, 
-			HookFunction hookFunction,
-			Address moduleBase)
-		{
-			memcpy(this, HookCallCodeData, HookCallCodeDataSize);
-			
-			ModuleBase							= reinterpret_cast<DWORD>(moduleBase);
+        HookCallCode()
+        {
+            memcpy(this, HookCallCodeData, HookCallCodeDataSize);
+        }
+        HookCallCode(
+            Address refNextInstruction,
+            Address base, 
+            HookFunction hookFunction,
+            Address moduleBase)
+        {
+            memcpy(this, HookCallCodeData, HookCallCodeDataSize);
+            
+            ModuleBase          = reinterpret_cast<DWORD>(moduleBase);
 
-			RefNextInstruction1				= refNextInstruction;
-			RefNextInstruction2				= refNextInstruction;
-			RefNextInstruction3				= refNextInstruction;
-			RefNextInstruction4				= refNextInstruction;
+            RefNextInstruction1 = refNextInstruction;
+            RefNextInstruction2 = refNextInstruction;
+            RefNextInstruction3 = refNextInstruction;
+            RefNextInstruction4 = refNextInstruction;
 
-			FunctionProcRelativeAddress	= relative_offset(
-				reinterpret_cast<BYTE*>(base) + HookCallCodeCallOffset + CallR32InstructionLength, 
-				static_cast<Address>(hookFunction));
-		}
-	};
-	static constexpr size_t HookCallCodeSize = sizeof(HookCallCode);
-	#pragma pack(pop)
+            FunctionProcRelativeAddress = relative_offset(
+                reinterpret_cast<BYTE*>(base) + HookCallCodeCallOffset + CallR32InstructionLength, 
+                static_cast<Address>(hookFunction));
+        }
+    };
+    static constexpr size_t HookCallCodeSize = sizeof(HookCallCode);
+    #pragma pack(pop)
 
-	static_assert(HookCallCodeSize == HookCallCodeDataSize, "The code and data are not equals");
+    static_assert(HookCallCodeSize == HookCallCodeDataSize, "The code and data are not equals");
 
-	struct HookPocket
-	{
-		size_t									Offset = 0;
-		list<Hook*>							Hooks;
-		size_t									OverriddenCount = 0;
+    struct HookPocket
+    {
+        size_t               Offset = 0;
+        list<Hook*>          Hooks;
+        size_t               OverriddenCount = 0;
 
-		JumpCode								HookCallerBlockCode;
-		RegistersBuildCode					RegistersBuild;
-		vector<HookCallCode>			HookCallBlocks;
-		RegistersCleanupCode				RegistersCleanup;
-		vector<BYTE>						OriginalBytes;
-		JumpCode								JumpBackCode;
-	};
-	
-	class HookInjector final
-	{
-	public:
-		ProcessMemory&					Memory;
-		list<Module>&						Modules;
+        JumpCode             HookCallerBlockCode;
+        RegistersBuildCode   RegistersBuild;
+        vector<HookCallCode> HookCallBlocks;
+        RegistersCleanupCode RegistersCleanup;
+        vector<BYTE>         OriginalBytes;
+        JumpCode             JumpBackCode;
+    };
+    
+    class HookInjector final
+    {
+    public:
+        ProcessMemory&           Memory;
+        list<Module>&            Modules;
 
-		VirtualMemoryHandle*			NextInstructionsVmh;
-		VirtualMemoryHandle*			ProgramVmh;
-		
-		map<Address, HookPocket>	Pockets;
+        VirtualMemoryHandle*     NextInstructionsVmh;
+        VirtualMemoryHandle*     ProgramVmh;
+        
+        map<Address, HookPocket> Pockets;
 
-		HookInjector(Debugger::DebugLoop& dbg, list<Module>& modules);
-		~HookInjector();
-	};
+        HookInjector(Debugger::DebugLoop& dbg, list<Module>& modules);
+        ~HookInjector();
+    };
 }
 #endif //INJECTOR_HOOK_INJECTOR_HPP

--- a/injector/hook_retriever.cpp
+++ b/injector/hook_retriever.cpp
@@ -2,74 +2,74 @@
 
 namespace Injector
 {
-	inline size_t calculate_total_hook_count(list<Module> const& modules)
-	{
-		size_t total = 0;
-		for (auto& mdl : modules)
-			total += mdl.Hooks.size();
-		return total;
-	}
-	inline Address write_string(string str, VirtualMemoryHandle& vmh, size_t index)
-	{
-		vmh.Write(const_cast<char*>(str.c_str()), str.size() + 1, HookRetriever::ProcNameLength * index);
-		return vmh.Pointer(HookRetriever::ProcNameLength * index);
-	}
+    inline size_t calculate_total_hook_count(list<Module> const& modules)
+    {
+        size_t total = 0;
+        for (auto& mdl : modules)
+            total += mdl.Hooks.size();
+        return total;
+    }
+    inline Address write_string(string str, VirtualMemoryHandle& vmh, size_t index)
+    {
+        vmh.Write(const_cast<char*>(str.c_str()), str.size() + 1, HookRetriever::ProcNameLength * index);
+        return vmh.Pointer(HookRetriever::ProcNameLength * index);
+    }
 
-	HookRetriever::HookRetriever(
-		ProcessMemory& memory,
-		Kernel32& kernel,
-		list<Module>& modules)	:
-			Memory(memory), Kernel(kernel),
-			Modules(modules),
-			TotalHookCount(calculate_total_hook_count(modules))
-	{
-		InitFuncNameVmh							= &Memory.Allocate(ProcNameLength);
-		InitFunctionsVmh							= &Memory.Allocate(sizeof(FARPROC) * Modules.size());
-		Address const initFunctionName		= write_string(InitializerFunctionName, *InitFuncNameVmh, 0);
+    HookRetriever::HookRetriever(
+        ProcessMemory& memory,
+        Kernel32& kernel,
+        list<Module>& modules):
+            Memory(memory), Kernel(kernel),
+            Modules(modules),
+            TotalHookCount(calculate_total_hook_count(modules))
+    {
+        InitFuncNameVmh                = &Memory.Allocate(ProcNameLength);
+        InitFunctionsVmh               = &Memory.Allocate(sizeof(FARPROC) * Modules.size());
+        Address const initFunctionName = write_string(InitializerFunctionName, *InitFuncNameVmh, 0);
 
-		FuncNamesVmh								= &Memory.Allocate(ProcNameLength * TotalHookCount);
-		HookFunctionsVmh							= &Memory.Allocate(sizeof(FARPROC) * TotalHookCount);
-		
-		CodeBlocks.reserve(TotalHookCount + Modules.size());				
-		
-		size_t thkIndex = 0;
-		for (size_t index = 0; index < Modules.size(); ++index)
-		{				
-			Module&		mdl						= *std::next(Modules.begin(), index);
-			HMODULE		handle					= mdl.get_handle();
+        FuncNamesVmh                   = &Memory.Allocate(ProcNameLength * TotalHookCount);
+        HookFunctionsVmh               = &Memory.Allocate(sizeof(FARPROC) * TotalHookCount);
+        
+        CodeBlocks.reserve(TotalHookCount + Modules.size());                
+        
+        size_t thkIndex = 0;
+        for (size_t index = 0; index < Modules.size(); ++index)
+        {                
+            Module& mdl    = *std::next(Modules.begin(), index);
+            HMODULE handle = mdl.get_handle();
 
-			Address const refInitFunction		= InitFunctionsVmh->Pointer(index * sizeof(FARPROC));
-			CodeBlocks.emplace_back((LPCSTR) initFunctionName, handle, Kernel.GetProcAddressFunc, (FARPROC*)refInitFunction);
+            Address const refInitFunction = InitFunctionsVmh->Pointer(index * sizeof(FARPROC));
+            CodeBlocks.emplace_back((LPCSTR) initFunctionName, handle, Kernel.GetProcAddressFunc, (FARPROC*)refInitFunction);
 
-			for (auto& hook : mdl.Hooks)
-			{
-				Address const funcName = write_string(hook.FunctionName, *FuncNamesVmh, thkIndex);
-				Address const refHookFunction = HookFunctionsVmh->Pointer(thkIndex++ * sizeof(FARPROC));
+            for (auto& hook : mdl.Hooks)
+            {
+                Address const funcName        = write_string(hook.FunctionName, *FuncNamesVmh, thkIndex);
+                Address const refHookFunction = HookFunctionsVmh->Pointer(thkIndex++ * sizeof(FARPROC));
 
-				CodeBlocks.emplace_back((LPCSTR) funcName, handle, Kernel.GetProcAddressFunc, (FARPROC*) refHookFunction);
-			}
-		}
-		
-		size_t const codeSize = CodeBlocks.size() * sizeof(GetProcAddressCode);
-		size_t const base = PrefixCodeSize + codeSize;
-		size_t const programSize = base + PostfixCodeSize;
+                CodeBlocks.emplace_back((LPCSTR) funcName, handle, Kernel.GetProcAddressFunc, (FARPROC*) refHookFunction);
+            }
+        }
+        
+        size_t const codeSize    = CodeBlocks.size() * sizeof(GetProcAddressCode);
+        size_t const base        = PrefixCodeSize + codeSize;
+        size_t const programSize = base + PostfixCodeSize;
 
-		BreakpointOffset = base + 2;
+        BreakpointOffset = base + 2;
 
-		ProgramVmh = &Memory.Allocate(programSize);
-		ProgramVmh->Write(&PrxCode, PrefixCodeSize, 0);
-		ProgramVmh->Write(CodeBlocks.data(), codeSize, PrefixCodeSize);
-		ProgramVmh->Write(&PstxCode, PostfixCodeSize, base);
-	}
-	HookRetriever::~HookRetriever()
-	{
-		Memory.Free(*InitFuncNameVmh);
-		Memory.Free(*FuncNamesVmh);
-		Memory.Free(*InitFunctionsVmh);
-		Memory.Free(*HookFunctionsVmh);
-		Memory.Free(*ProgramVmh);
-	}
-	
-	Address HookRetriever::breakpoint() const { return ProgramVmh->Pointer(BreakpointOffset); }
-	Address HookRetriever::instruction() const { return ProgramVmh->Pointer(); }
+        ProgramVmh = &Memory.Allocate(programSize);
+        ProgramVmh->Write(&PrxCode, PrefixCodeSize, 0);
+        ProgramVmh->Write(CodeBlocks.data(), codeSize, PrefixCodeSize);
+        ProgramVmh->Write(&PstxCode, PostfixCodeSize, base);
+    }
+    HookRetriever::~HookRetriever()
+    {
+        Memory.Free(*InitFuncNameVmh);
+        Memory.Free(*FuncNamesVmh);
+        Memory.Free(*InitFunctionsVmh);
+        Memory.Free(*HookFunctionsVmh);
+        Memory.Free(*ProgramVmh);
+    }
+    
+    Address HookRetriever::breakpoint()  const { return ProgramVmh->Pointer(BreakpointOffset); }
+    Address HookRetriever::instruction() const { return ProgramVmh->Pointer(); }
 }

--- a/injector/hook_retriever.hpp
+++ b/injector/hook_retriever.hpp
@@ -11,38 +11,38 @@
 
 namespace Injector
 {
-	using namespace PECOFF;
+    using namespace PECOFF;
 
-	class HookRetriever final
-	{
-	public:
-		static size_t constexpr				ProcNameLength = sizeof(char) * (MaxProcNameLength + 1);
-	public:
-		ProcessMemory&						Memory;
-		Kernel32&									Kernel;
-		list<Module>&							Modules;
+    class HookRetriever final
+    {
+    public:
+        static size_t constexpr ProcNameLength = sizeof(char) * (MaxProcNameLength + 1);
+    public:
+        ProcessMemory& Memory;
+        Kernel32&      Kernel;
+        list<Module>&  Modules;
 
-		size_t										BreakpointOffset;
-		size_t const								TotalHookCount;
+        size_t               BreakpointOffset;
+        size_t const         TotalHookCount;
 
-		VirtualMemoryHandle*				InitFuncNameVmh;
-		VirtualMemoryHandle*				FuncNamesVmh;
-		VirtualMemoryHandle*				InitFunctionsVmh;
-		VirtualMemoryHandle*				HookFunctionsVmh;
-		VirtualMemoryHandle*				ProgramVmh;
+        VirtualMemoryHandle* InitFuncNameVmh;
+        VirtualMemoryHandle* FuncNamesVmh;
+        VirtualMemoryHandle* InitFunctionsVmh;
+        VirtualMemoryHandle* HookFunctionsVmh;
+        VirtualMemoryHandle* ProgramVmh;
 
-		PrefixCode									PrxCode;
-		vector<GetProcAddressCode>		CodeBlocks;
-		PostfixCode								PstxCode;
+        PrefixCode                 PrxCode;
+        vector<GetProcAddressCode> CodeBlocks;
+        PostfixCode                PstxCode;
 
-		HookRetriever(
-			ProcessMemory& memory,
-			Kernel32& kernel,
-			list<Module>& modules);
-		~HookRetriever();
-		
-		Address breakpoint() const;
-		Address instruction() const;
-	};
+        HookRetriever(
+            ProcessMemory& memory,
+            Kernel32& kernel,
+            list<Module>& modules);
+        ~HookRetriever();
+        
+        Address breakpoint() const;
+        Address instruction() const;
+    };
 }
 #endif //INJECTOR_HOOK_RETRIEVER_HPP

--- a/injector/load_library_code.hpp
+++ b/injector/load_library_code.hpp
@@ -7,114 +7,114 @@
 #include "asm.hpp"
 
 namespace Injector
-{	
-	using PECOFF::LoadLibraryFunction;
+{
+    using PECOFF::LoadLibraryFunction;
 
-	struct library_name_out_of_range_error : std::exception {};	
-	
-	BYTE const LoadLibraryCodeData[] =
-	{
-		PUSH_INTO_STACK(INIT_PTR), // 0, 1-2-3-4 - pointer to libname, 
-		CALL_PTR32(INIT_PTR), // 5-6, 7-8-9-10 - pointer to imported in process LoadLibraryA function.
-		MOV_EAX_TO(INIT_PTR), // 11, 12-13-14-15 - address for handle. It is return value of the function.
-	};
-	static constexpr size_t LoadLibraryCodeDataSize = sizeof(LoadLibraryCodeData);
-	#pragma pack(push, 1)
-	struct LoadLibraryCode
-	{
-		BYTE arr1[1] { 0 };
-		LPCSTR LibraryFileName { nullptr };
-		BYTE arr2[2] { 0, 0 };
-		LoadLibraryFunction LoadLibraryA { nullptr };
-		BYTE arr3[1] { 0 };
-		HMODULE* RefHandlePointer { nullptr };
-		//BYTE arr4[1] { 0 };
+    struct library_name_out_of_range_error : std::exception {};
+    
+    BYTE const LoadLibraryCodeData[] =
+    {
+        PUSH_INTO_STACK(INIT_PTR), // 0, 1-2-3-4 - pointer to libname, 
+        CALL_PTR32(INIT_PTR), // 5-6, 7-8-9-10 - pointer to imported in process LoadLibraryA function.
+        MOV_EAX_TO(INIT_PTR), // 11, 12-13-14-15 - address for handle. It is return value of the function.
+    };
+    static constexpr size_t LoadLibraryCodeDataSize = sizeof(LoadLibraryCodeData);
+    #pragma pack(push, 1)
+    struct LoadLibraryCode
+    {
+        BYTE arr1[1] { 0 };
+        LPCSTR LibraryFileName { nullptr };
+        BYTE arr2[2] { 0, 0 };
+        LoadLibraryFunction LoadLibraryA { nullptr };
+        BYTE arr3[1] { 0 };
+        HMODULE* RefHandlePointer { nullptr };
+        //BYTE arr4[1] { 0 };
 
-		LoadLibraryCode() noexcept = default;
-		LoadLibraryCode(
-			LPCSTR libFileName,
-			LoadLibraryFunction loadLibraryFunction,
-			HMODULE* refHandlePointer)
-		{
-			memcpy(this, &LoadLibraryCodeData, LoadLibraryCodeDataSize);
-			LibraryFileName = libFileName;
-			LoadLibraryA = loadLibraryFunction;
-			RefHandlePointer = refHandlePointer;
-		}
-	};
-	static constexpr size_t LoadLibraryCodeSize = sizeof(LoadLibraryCode);
-	#pragma pack(pop)
-	static_assert(LoadLibraryCodeDataSize == LoadLibraryCodeSize, "The code and data are not equals");
-	
-	class LoadLibraryCodeHandle final
-	{		
-		ProcessMemory& _processMemory;
-	
-		size_t _libraryNameLength = 0;
-		CHAR* _libraryNameBuffer = new CHAR[MaxLibraryNameLength + 1];
-		VirtualMemoryHandle& _libraryNameMemoryHandle;
+        LoadLibraryCode() noexcept = default;
+        LoadLibraryCode(
+            LPCSTR libFileName,
+            LoadLibraryFunction loadLibraryFunction,
+            HMODULE* refHandlePointer)
+        {
+            memcpy(this, &LoadLibraryCodeData, LoadLibraryCodeDataSize);
+            LibraryFileName = libFileName;
+            LoadLibraryA = loadLibraryFunction;
+            RefHandlePointer = refHandlePointer;
+        }
+    };
+    static constexpr size_t LoadLibraryCodeSize = sizeof(LoadLibraryCode);
+    #pragma pack(pop)
+    static_assert(LoadLibraryCodeDataSize == LoadLibraryCodeSize, "The code and data are not equals");
+    
+    class LoadLibraryCodeHandle final
+    {        
+        ProcessMemory& _processMemory;
 
-		HMODULE _handleBuffer = nullptr;
-		VirtualMemoryHandle& _handleMemoryHandle;
+        size_t _libraryNameLength = 0;
+        CHAR*  _libraryNameBuffer = new CHAR[MaxLibraryNameLength + 1];
+        VirtualMemoryHandle& _libraryNameMemoryHandle;
 
-		LoadLibraryCode _code;
-		VirtualMemoryHandle& _codeMemoryHandle;	
+        HMODULE _handleBuffer = nullptr;
+        VirtualMemoryHandle& _handleMemoryHandle;
 
-	public:
-		LoadLibraryCodeHandle(
-			LoadLibraryFunction loadLibFunction, 
-			ProcessMemory& processMemory) :
-				_processMemory(processMemory),
-				_libraryNameMemoryHandle(processMemory.Allocate(MaxLibraryNameLength + 1)),
-				_handleMemoryHandle(processMemory.Allocate(sizeof(HMODULE))),
-				_codeMemoryHandle(processMemory.Allocate(LoadLibraryCodeDataSize))
-		{			
-			memcpy(&_code, LoadLibraryCodeData, LoadLibraryCodeDataSize);
+        LoadLibraryCode _code;
+        VirtualMemoryHandle& _codeMemoryHandle;    
 
-			_code.LoadLibraryA = loadLibFunction;
-			_code.LibraryFileName = reinterpret_cast<LPCSTR>(_libraryNameMemoryHandle.Pointer());
-			_code.RefHandlePointer = reinterpret_cast<HMODULE*>(_handleMemoryHandle.Pointer());
+    public:
+        LoadLibraryCodeHandle(
+            LoadLibraryFunction loadLibFunction, 
+            ProcessMemory& processMemory) :
+                _processMemory(processMemory),
+                _libraryNameMemoryHandle(processMemory.Allocate(MaxLibraryNameLength + 1)),
+                _handleMemoryHandle(processMemory.Allocate(sizeof(HMODULE))),
+                _codeMemoryHandle(processMemory.Allocate(LoadLibraryCodeDataSize))
+        {            
+            memcpy(&_code, LoadLibraryCodeData, LoadLibraryCodeDataSize);
 
-			_codeMemoryHandle.Write(&_code, LoadLibraryCodeDataSize, 0);
-		}
-		~LoadLibraryCodeHandle()
-		{
-			_handleBuffer = nullptr;
-			_libraryNameLength = 0;
+            _code.LoadLibraryA     = loadLibFunction;
+            _code.LibraryFileName  = reinterpret_cast<LPCSTR>(_libraryNameMemoryHandle.Pointer());
+            _code.RefHandlePointer = reinterpret_cast<HMODULE*>(_handleMemoryHandle.Pointer());
 
-			delete[] _libraryNameBuffer;
+            _codeMemoryHandle.Write(&_code, LoadLibraryCodeDataSize, 0);
+        }
+        ~LoadLibraryCodeHandle()
+        {
+            _handleBuffer = nullptr;
+            _libraryNameLength = 0;
 
-			_processMemory.Free(_codeMemoryHandle);
-			_processMemory.Free(_handleMemoryHandle);
-			_processMemory.Free(_libraryNameMemoryHandle);
-		}
+            delete[] _libraryNameBuffer;
 
-		void SetLibraryName(string_view const& libraryName)
-		{
-			if (libraryName.size() > MaxLibraryNameLength)
-				throw library_name_out_of_range_error();
-			
-			_libraryNameMemoryHandle.Write(const_cast<char*>(libraryName.data()), libraryName.size() + 1, 0);
+            _processMemory.Free(_codeMemoryHandle);
+            _processMemory.Free(_handleMemoryHandle);
+            _processMemory.Free(_libraryNameMemoryHandle);
+        }
 
-			_libraryNameLength = libraryName.size();
-		}
-		string_view const& LibraryName() const
-		{
-			if (_libraryNameLength == 0)
-				return nullptr;
+        void SetLibraryName(string_view const& libraryName)
+        {
+            if (libraryName.size() > MaxLibraryNameLength)
+                throw library_name_out_of_range_error();
+            
+            _libraryNameMemoryHandle.Write(const_cast<char*>(libraryName.data()), libraryName.size() + 1, 0);
 
-			_libraryNameMemoryHandle.Read(0, _libraryNameLength + 1, _libraryNameBuffer);
-			return _libraryNameBuffer;
-		}
+            _libraryNameLength = libraryName.size();
+        }
+        string_view const& LibraryName() const
+        {
+            if (_libraryNameLength == 0)
+                return nullptr;
 
-		HMODULE Handle() const
-		{ 
-			_handleMemoryHandle.Read(0, sizeof(HMODULE), const_cast<HMODULE*>(&_handleBuffer));
+            _libraryNameMemoryHandle.Read(0, _libraryNameLength + 1, _libraryNameBuffer);
+            return _libraryNameBuffer;
+        }
 
-			return _handleBuffer;
-		}
+        HMODULE Handle() const
+        { 
+            _handleMemoryHandle.Read(0, sizeof(HMODULE), const_cast<HMODULE*>(&_handleBuffer));
 
-		Address Instruction() const { return _codeMemoryHandle.Pointer(); }
-	};
+            return _handleBuffer;
+        }
+
+        Address Instruction() const { return _codeMemoryHandle.Pointer(); }
+    };
 }
 #endif //INJECTOR_LOAD_LIBRARY_CODE_HPP

--- a/injector/misc_code.hpp
+++ b/injector/misc_code.hpp
@@ -6,109 +6,109 @@
 
 namespace Injector
 {
-	static constexpr size_t CallR32InstructionLength		= 5;
-	static constexpr size_t JumpR32lInstructionLength	= 5;
-	
-	BYTE const PrefixCodeData[] =
-	{
-		PUSH_EAX
-	};
-	static constexpr size_t PrefixCodeDataSize = sizeof(PrefixCodeData);	
-	#pragma pack(push, 1)
-	struct PrefixCode
-	{
-		BYTE arr1[1] { 0 };
+    static constexpr size_t CallR32InstructionLength  = 5;
+    static constexpr size_t JumpR32lInstructionLength = 5;
+    
+    BYTE const PrefixCodeData[] =
+    {
+        PUSH_EAX
+    };
+    static constexpr size_t PrefixCodeDataSize = sizeof(PrefixCodeData);
+    #pragma pack(push, 1)
+    struct PrefixCode
+    {
+        BYTE arr1[1] { 0 };
 
-		PrefixCode()
-		{
-			memcpy(this, &PrefixCodeData, PrefixCodeDataSize);
-		}
-	};
-	static constexpr size_t PrefixCodeSize = sizeof(PrefixCode);
-	#pragma pack(pop)
-	static_assert(PrefixCodeDataSize == PrefixCodeSize, "The code and data are not equals");
-		
-	BYTE const PostfixCodeData[] =
-	{
-		POP_EAX,
-		DEBUGGER_INTERRUPT_CODE, NOP
-	};
-	static constexpr size_t PostfixCodeDataSize = sizeof(PostfixCodeData);
-	static constexpr size_t PostfixCodeBreakpointOffset = 1;
-	#pragma pack(push, 1)
-	struct PostfixCode
-	{
-		BYTE arr1[3] { 0, 0, 0 };
+        PrefixCode()
+        {
+            memcpy(this, &PrefixCodeData, PrefixCodeDataSize);
+        }
+    };
+    static constexpr size_t PrefixCodeSize = sizeof(PrefixCode);
+    #pragma pack(pop)
+    static_assert(PrefixCodeDataSize == PrefixCodeSize, "The code and data are not equals");
 
-		PostfixCode()
-		{
-			memcpy(this, &PostfixCodeData, PostfixCodeDataSize);
-		}
-	};
-	static constexpr size_t PostfixCodeSize = sizeof(PostfixCode);
-	#pragma pack(pop)
-	static_assert(PostfixCodeDataSize == PostfixCodeSize, "The code and data are not equals");
+    BYTE const PostfixCodeData[] =
+    {
+        POP_EAX,
+        DEBUGGER_INTERRUPT_CODE, NOP
+    };
+    static constexpr size_t PostfixCodeDataSize = sizeof(PostfixCodeData);
+    static constexpr size_t PostfixCodeBreakpointOffset = 1;
+    #pragma pack(push, 1)
+    struct PostfixCode
+    {
+        BYTE arr1[3] { 0, 0, 0 };
 
-	BYTE const JumpCodeData[] =
-	{
-		JMP_R32(INIT_PTR)
-	};
-	static constexpr size_t JumpCodeDataSize = sizeof(JumpCodeData);
-	
-	#pragma pack(push, 1)
-	struct JumpCode
-	{
-		// 0xE9
-		BYTE JumpOpCode;
-		// Jump to relative address
-		DWORD Offset;
-	
-		JumpCode()
-		{
-			memcpy(this, JumpCodeData, JumpCodeDataSize);
-		}
-		JumpCode(Address base, Address target)
-		{
-			memcpy(this, JumpCodeData, JumpCodeDataSize);
-			Offset = relative_offset(
-				reinterpret_cast<BYTE*>(base) + JumpR32lInstructionLength, 
-				target);
-		}
-	};
-	static constexpr size_t JumpCodeSize = sizeof(JumpCode);
-	#pragma pack(pop)
+        PostfixCode()
+        {
+            memcpy(this, &PostfixCodeData, PostfixCodeDataSize);
+        }
+    };
+    static constexpr size_t PostfixCodeSize = sizeof(PostfixCode);
+    #pragma pack(pop)
+    static_assert(PostfixCodeDataSize == PostfixCodeSize, "The code and data are not equals");
 
-	static_assert(JumpCodeSize == JumpCodeDataSize, "The code and data are not equals");
-	
-	BYTE const CallCodeData[] =
-	{
-		CALL_R32(INIT_PTR)
-	};
-	static constexpr size_t CallCodeDataSize = sizeof(CallCodeData);
-	
-	#pragma pack(push, 1)
-	struct CallCode
-	{
-		// 0xE8
-		BYTE CallOpCode;
-		// Call function at relative offset.
-		DWORD Offset;
-	
-		CallCode()
-		{
-			memcpy(this, CallCodeData, CallCodeDataSize);
-		}
-		CallCode(Address base, FARPROC func)
-		{
-			memcpy(this, CallCodeData, CallCodeDataSize);
-			Offset = relative_offset(
-				reinterpret_cast<BYTE*>(base) + JumpR32lInstructionLength, 
-				func);
-		}
-	};
-	static constexpr size_t CallCodeSize = sizeof(CallCode);
-	#pragma pack(pop)
+    BYTE const JumpCodeData[] =
+    {
+        JMP_R32(INIT_PTR)
+    };
+    static constexpr size_t JumpCodeDataSize = sizeof(JumpCodeData);
+    
+    #pragma pack(push, 1)
+    struct JumpCode
+    {
+        // 0xE9
+        BYTE JumpOpCode;
+        // Jump to relative address
+        DWORD Offset;
+    
+        JumpCode()
+        {
+            memcpy(this, JumpCodeData, JumpCodeDataSize);
+        }
+        JumpCode(Address base, Address target)
+        {
+            memcpy(this, JumpCodeData, JumpCodeDataSize);
+            Offset = relative_offset(
+                reinterpret_cast<BYTE*>(base) + JumpR32lInstructionLength, 
+                target);
+        }
+    };
+    static constexpr size_t JumpCodeSize = sizeof(JumpCode);
+    #pragma pack(pop)
 
-	static_assert(CallCodeSize == CallCodeDataSize, "The code and data are not equals");
+    static_assert(JumpCodeSize == JumpCodeDataSize, "The code and data are not equals");
+
+    BYTE const CallCodeData[] =
+    {
+        CALL_R32(INIT_PTR)
+    };
+    static constexpr size_t CallCodeDataSize = sizeof(CallCodeData);
+    
+    #pragma pack(push, 1)
+    struct CallCode
+    {
+        // 0xE8
+        BYTE CallOpCode;
+        // Call function at relative offset.
+        DWORD Offset;
+
+        CallCode()
+        {
+            memcpy(this, CallCodeData, CallCodeDataSize);
+        }
+        CallCode(Address base, FARPROC func)
+        {
+            memcpy(this, CallCodeData, CallCodeDataSize);
+            Offset = relative_offset(
+                reinterpret_cast<BYTE*>(base) + JumpR32lInstructionLength, 
+                func);
+        }
+    };
+    static constexpr size_t CallCodeSize = sizeof(CallCode);
+    #pragma pack(pop)
+
+    static_assert(CallCodeSize == CallCodeDataSize, "The code and data are not equals");
 }
 #endif //INJECTOR_MISC_CODE_HPP

--- a/injector/module.cpp
+++ b/injector/module.cpp
@@ -4,201 +4,201 @@
 
 namespace Injector
 {
-	using PE		= PECOFF::PortableExecutable;
-	using CRC32	= Utilities::CRC32;
+    using PE    = PECOFF::PortableExecutable;
+    using CRC32 = Utilities::CRC32;
 
-	void Module::parse_hosts()
-	{
-		auto& hostsSection				= _pe.find_section(HostsPESectionName);
-		auto const base					= _pe.PEHeader.OptionalHeader.ImageBase;		
-		auto const begin					= hostsSection.PointerToRawData;
-		auto const end					= begin + hostsSection.SizeOfRawData;
-		
-		for (auto ptr = begin; ptr < end; ptr += sizeof(HostDecl))
-		{
-			std::string hostName;
-			HostDecl h;
-			if (PE::read_bytes(_ifs, ptr, sizeof(HostDecl), &h)	&& h.NamePtr &&
-				PE::read_cstring(_ifs, PE::virtual_to_raw(h.NamePtr - base, _pe.Sections), hostName))
-			{ 
-				Hosts.emplace_back(hostName, h.Checksum);
-			}
-		}
-	}
-	void Module::parse_generic_hooks()
-	{
-		size_t const declSize	= sizeof(HookDecl);
+    void Module::parse_hosts()
+    {
+        auto& hostsSection = _pe.find_section(HostsPESectionName);
+        auto const base    = _pe.PEHeader.OptionalHeader.ImageBase;
+        auto const begin   = hostsSection.PointerToRawData;
+        auto const end     = begin + hostsSection.SizeOfRawData;
+        
+        for (auto ptr = begin; ptr < end; ptr += sizeof(HostDecl))
+        {
+            std::string hostName;
+            HostDecl h;
+            if (PE::read_bytes(_ifs, ptr, sizeof(HostDecl), &h)    && h.NamePtr &&
+                PE::read_cstring(_ifs, PE::virtual_to_raw(h.NamePtr - base, _pe.Sections), hostName))
+            { 
+                Hosts.emplace_back(hostName, h.Checksum);
+            }
+        }
+    }
+    void Module::parse_generic_hooks()
+    {
+        size_t const declSize = sizeof(HookDecl);
 
-		auto const base			= _pe.PEHeader.OptionalHeader.ImageBase;
+        auto const base       = _pe.PEHeader.OptionalHeader.ImageBase;
 
-		auto&		section		= _pe.find_section(GenericHooksPESectionName);
-		auto const begin			= section.PointerToRawData;
-		auto const end			= begin + section.SizeOfRawData;
+        auto&      section    = _pe.find_section(GenericHooksPESectionName);
+        auto const begin      = section.PointerToRawData;
+        auto const end        = begin + section.SizeOfRawData;
 
-		for (auto ptr = begin; ptr < end; ptr += declSize)
-		{
-			HookDecl h;
-			if (PE::read_bytes(_ifs, ptr, declSize, &h))
-			{
-				// msvc linker inserts arbitrary padding between variables that come
-				// from different translation units
-				if (h.FunctionNamePtr)
-				{
-					std::string functionName;
-					if (PE::read_cstring(_ifs, PE::virtual_to_raw(h.FunctionNamePtr - base, _pe.Sections), functionName))
-					{
-						Hook& hook						= Hooks.emplace_back(functionName, h);
-						hook.Placement					= reinterpret_cast<Address>(h.Address);
-						hook.Size							= h.Size;			
-					}
-				}
-			}
-			else throw construct_error_no_msg(file_read_error);
-		}
-	}
-	void Module::parse_extended_hooks()
-	{
-		size_t const declSize	= sizeof(ExtendedHookDecl);
+        for (auto ptr = begin; ptr < end; ptr += declSize)
+        {
+            HookDecl h;
+            if (PE::read_bytes(_ifs, ptr, declSize, &h))
+            {
+                // msvc linker inserts arbitrary padding between variables that come
+                // from different translation units
+                if (h.FunctionNamePtr)
+                {
+                    std::string functionName;
+                    if (PE::read_cstring(_ifs, PE::virtual_to_raw(h.FunctionNamePtr - base, _pe.Sections), functionName))
+                    {
+                        Hook& hook     = Hooks.emplace_back(functionName, h);
+                        hook.Placement = reinterpret_cast<Address>(h.Address);
+                        hook.Size      = h.Size;            
+                    }
+                }
+            }
+            else throw construct_error_no_msg(file_read_error);
+        }
+    }
+    void Module::parse_extended_hooks()
+    {
+        size_t const declSize = sizeof(ExtendedHookDecl);
 
-		auto const base			= _pe.PEHeader.OptionalHeader.ImageBase;
+        auto const base       = _pe.PEHeader.OptionalHeader.ImageBase;
 
-		auto&		section		= _pe.find_section(ExtendedHooksPESectionName);
-		auto const begin			= section.PointerToRawData;
-		auto const end			= begin + section.SizeOfRawData;
+        auto&      section    = _pe.find_section(ExtendedHooksPESectionName);
+        auto const begin      = section.PointerToRawData;
+        auto const end        = begin + section.SizeOfRawData;
 
-		for (auto ptr = begin; ptr < end; ptr += declSize)
-		{
-			ExtendedHookDecl h;
-			if (PE::read_bytes(_ifs, ptr, declSize, &h))
-			{
-				// msvc linker inserts arbitrary padding between variables that come
-				// from different translation units
-				if(h.FunctionNamePtr)
-				{
-					std::string functionName;
-					std::string moduleName;
-					if (PE::read_cstring(_ifs, PE::virtual_to_raw(h.FunctionNamePtr - base, _pe.Sections), functionName) &&
-						PE::read_cstring(_ifs, PE::virtual_to_raw(h.ModuleNamePtr - base, _pe.Sections), moduleName))
-					{
-						Hook& hook						= Hooks.emplace_back(functionName, h);
-						hook.Placement					= reinterpret_cast<Address>(h.Address);
-						hook.Size							= h.Size;				
-						hook.ModuleName				= moduleName;
-						hook.ModuleChecksum		= h.ModuleChecksum;
-					}
-				}
-			}
-			else throw construct_error_no_msg(file_read_error);
-		}
-	}
-	void Module::parse_inj_file(string_view const& injFileName)
-	{
-		std::string inj = file_read_text(injFileName.data());
-		for (auto& line : string_split(inj, "\n"))
-		{
-			if (line.front() == ';')
-				continue;
+        for (auto ptr = begin; ptr < end; ptr += declSize)
+        {
+            ExtendedHookDecl h;
+            if (PE::read_bytes(_ifs, ptr, declSize, &h))
+            {
+                // msvc linker inserts arbitrary padding between variables that come
+                // from different translation units
+                if(h.FunctionNamePtr)
+                {
+                    std::string functionName;
+                    std::string moduleName;
+                    if (PE::read_cstring(_ifs, PE::virtual_to_raw(h.FunctionNamePtr - base, _pe.Sections), functionName) &&
+                        PE::read_cstring(_ifs, PE::virtual_to_raw(h.ModuleNamePtr - base, _pe.Sections), moduleName))
+                    {
+                        Hook& hook          = Hooks.emplace_back(functionName, h);
+                        hook.Placement      = reinterpret_cast<Address>(h.Address);
+                        hook.Size           = h.Size;                
+                        hook.ModuleName     = moduleName;
+                        hook.ModuleChecksum = h.ModuleChecksum;
+                    }
+                }
+            }
+            else throw construct_error_no_msg(file_read_error);
+        }
+    }
+    void Module::parse_inj_file(string_view const& injFileName)
+    {
+        std::string inj = file_read_text(injFileName.data());
+        for (auto& line : string_split(inj, "\n"))
+        {
+            if (line.front() == ';')
+                continue;
 
-			std::string		functionName; functionName.reserve(MaxFunctionNameLength);
-			size_t			size		= 0;
-			Address			address	= nullptr;
+            std::string functionName; functionName.reserve(MaxFunctionNameLength);
+            size_t      size    = 0;
+            Address     address = nullptr;
 
-			if (sscanf_s(line.c_str(), "%p = %[^ \t;,\r\n] , %x", 
-				&address, 
-				functionName.data(),
-				MaxFunctionNameLength, 
-				&size) >= 2)
-			{
-				Hook& hook						= Hooks.emplace_back(functionName, address, size);
-				hook.Placement					= address;
-				hook.Size							= size;
-			}
-		}
-	}
+            if (sscanf_s(line.c_str(), "%p = %[^ \t;,\r\n] , %x", 
+                &address, 
+                functionName.data(),
+                MaxFunctionNameLength, 
+                &size) >= 2)
+            {
+                Hook& hook     = Hooks.emplace_back(functionName, address, size);
+                hook.Placement = address;
+                hook.Size      = size;
+            }
+        }
+    }
 
-	Module::Module(string_view const& fileName)
-	{
-		parse(fileName);
-	}
-	void Module::parse(string_view const& fileName)
-	{
-		FileName			= fileName;
-		_ifs					= file_open_binary(FileName);
-		Checksum			= CRC32::compute_stream(_ifs);
-		_pe					= PE(_ifs);
-		_injectorHandle	= make_unique<HMODULE>(LoadLibrary(FileName.c_str()));
-		_handle				= nullptr;
+    Module::Module(string_view const& fileName)
+    {
+        parse(fileName);
+    }
+    void Module::parse(string_view const& fileName)
+    {
+        FileName        = fileName;
+        _ifs            = file_open_binary(FileName);
+        Checksum        = CRC32::compute_stream(_ifs);
+        _pe             = PE(_ifs);
+        _injectorHandle = make_unique<HMODULE>(LoadLibrary(FileName.c_str()));
+        _handle         = nullptr;
 
-		if (!_injectorHandle.get())
-			throw construct_error_args_no_msg(load_library_error, fileName);
+        if (!_injectorHandle.get())
+            throw construct_error_args_no_msg(load_library_error, fileName);
 
-		try { parse_hosts();					}	catch(const PE::section_not_found_error&)	{ };
-		try { parse_generic_hooks();		}	catch(const PE::section_not_found_error&)	{ };
-		try { parse_extended_hooks();	}	catch(const PE::section_not_found_error&)	{ };
-	}
-	Module::Module(string_view const& fileName, string_view const& injFileName)
-	{
-		parse(fileName, injFileName);
-	}
-	void Module::parse(string_view const& fileName, string_view const& injFileName)
-	{
-		FileName			= fileName;
-		_ifs					= file_open_binary(FileName);
-		Checksum			= CRC32::compute_stream(_ifs);
-		_pe					= PE(_ifs);
-		_injectorHandle	= make_unique<HMODULE>(LoadLibrary(FileName.c_str()));
-		_handle				= nullptr;
+        try { parse_hosts();          } catch(const PE::section_not_found_error&) { };
+        try { parse_generic_hooks();  } catch(const PE::section_not_found_error&) { };
+        try { parse_extended_hooks(); } catch(const PE::section_not_found_error&) { };
+    }
+    Module::Module(string_view const& fileName, string_view const& injFileName)
+    {
+        parse(fileName, injFileName);
+    }
+    void Module::parse(string_view const& fileName, string_view const& injFileName)
+    {
+        FileName        = fileName;
+        _ifs            = file_open_binary(FileName);
+        Checksum        = CRC32::compute_stream(_ifs);
+        _pe             = PE(_ifs);
+        _injectorHandle = make_unique<HMODULE>(LoadLibrary(FileName.c_str()));
+        _handle         = nullptr;
 
-		if (!_injectorHandle.get())
-			throw construct_error_args_no_msg(load_library_error, fileName);
+        if (!_injectorHandle.get())
+            throw construct_error_args_no_msg(load_library_error, fileName);
 
-		try { parse_inj_file(injFileName);	}	catch(const file_not_found_error&)	{ throw construct_error_args_no_msg(non_injectable_module_error, fileName, non_injectable_module_error::Type::MissingInj); };
-	}
+        try { parse_inj_file(injFileName); } catch(const file_not_found_error&) { throw construct_error_args_no_msg(non_injectable_module_error, fileName, non_injectable_module_error::Type::MissingInj); };
+    }
 
-	bool Module::is_host_supported(string_view const& executableFile, unsigned int checksum)
-	{
-		auto executablePath			= std::filesystem::path(executableFile);
-		auto executableFileName		= executablePath.stem().string();
-	
-		auto iter = std::find_if(Hosts.cbegin(), Hosts.cend(), [&executableFileName, &checksum](Host const& item) -> bool
-		{
-			return executableFileName == item.FileName && (checksum == 0 || checksum == item.Checksum);
-		});
+    bool Module::is_host_supported(string_view const& executableFile, unsigned int checksum)
+    {
+        auto executablePath     = std::filesystem::path(executableFile);
+        auto executableFileName = executablePath.stem().string();
+    
+        auto iter = std::find_if(Hosts.cbegin(), Hosts.cend(), [&executableFileName, &checksum](Host const& item) -> bool
+        {
+            return executableFileName == item.FileName && (checksum == 0 || checksum == item.Checksum);
+        });
 
-		return iter != Hosts.cend();
-	}
-	bool Module::handshake()
-	{
-		auto const function			= GetFunctionAddress<HandshakeFunction>(*_injectorHandle.get(), HandshakeFunctionName);
-		if (function)
-		{
-			constexpr auto			bufferLength = 0x100u;
-			vector<char>				buffer(bufferLength + 1); // one more than we tell the dll
+        return iter != Hosts.cend();
+    }
+    bool Module::handshake()
+    {
+        auto const function = GetFunctionAddress<HandshakeFunction>(*_injectorHandle.get(), HandshakeFunctionName);
+        if (function)
+        {
+            constexpr auto bufferLength = 0x100u;
+            vector<char>   buffer(bufferLength + 1); // one more than we tell the dll
 
-			HandshakeInfo			hsInfo;
-			HandshakeResult		hsResult;
+            HandshakeInfo   hsInfo;
+            HandshakeResult hsResult;
 
-			auto fs						= file_open_binary(FileName);
+            auto fs = file_open_binary(FileName);
 
-			hsInfo.cbSize				= sizeof(HandshakeInfo);
-			hsInfo.num_hooks		= Hooks.size();
-			hsInfo.exeFilesize		= file_size(fs);
-			hsInfo.checksum		= CRC32::compute_stream(fs);
-			hsInfo.exeTimestamp	= _pe.PEHeader.FileHeader.TimeDateStamp;
-			hsInfo.cchMessage		= static_cast<int>(bufferLength);
-			hsInfo.Message			= buffer.data();
+            hsInfo.cbSize       = sizeof(HandshakeInfo);
+            hsInfo.num_hooks    = Hooks.size();
+            hsInfo.exeFilesize  = file_size(fs);
+            hsInfo.checksum     = CRC32::compute_stream(fs);
+            hsInfo.exeTimestamp = _pe.PEHeader.FileHeader.TimeDateStamp;
+            hsInfo.cchMessage   = static_cast<int>(bufferLength);
+            hsInfo.Message      = buffer.data();
 
-			auto const result = function(&hsInfo);
+            auto const result = function(&hsInfo);
 
-			hsResult.Code = result;
-			hsResult.Success = SUCCEEDED(result);
+            hsResult.Code = result;
+            hsResult.Success = SUCCEEDED(result);
 
-			return hsResult.Success;
-		}
-		return false;
-	}
-	bool Module::is_executable_supported(string_view const& executableFile, unsigned int checksum)
-	{
-		return is_host_supported(executableFile, checksum) || handshake();
-	}
+            return hsResult.Success;
+        }
+        return false;
+    }
+    bool Module::is_executable_supported(string_view const& executableFile, unsigned int checksum)
+    {
+        return is_host_supported(executableFile, checksum) || handshake();
+    }
 }

--- a/injector/module.hpp
+++ b/injector/module.hpp
@@ -10,85 +10,85 @@
 
 namespace Injector
 {
-	using namespace Utilities;
-	using namespace Exceptions;
+    using namespace Utilities;
+    using namespace Exceptions;
 
-	struct executable_not_supported_error : public base_error
-	{
-		std::string const FileName;
+    struct executable_not_supported_error : public base_error
+    {
+        std::string const FileName;
 
-		executable_not_supported_error(std::string function, std::string file, int line, std::string_view const& fileName) : base_error("Executable not supported  by " + std::string(fileName), function, file, line), FileName(fileName) {}
-		executable_not_supported_error(std::string msg, std::string function, std::string file, int line, std::string_view const& fileName) : base_error(msg, function, file, line), FileName(fileName) { }
-	};
+        executable_not_supported_error(std::string function, std::string file, int line, std::string_view const& fileName) : base_error("Executable not supported  by " + std::string(fileName), function, file, line), FileName(fileName) {}
+        executable_not_supported_error(std::string msg, std::string function, std::string file, int line, std::string_view const& fileName) : base_error(msg, function, file, line), FileName(fileName) { }
+    };
 
-	struct file_read_error : public base_error
-	{
-		file_read_error(std::string function, std::string file, int line) : base_error("File read not possible", function, file, line) {}
-		file_read_error(std::string msg, std::string function, std::string file, int line) : base_error(msg, function, file, line) { }
-	};
-	struct non_injectable_module_error : public base_error
-	{
-		enum class Type
-		{
-			MissingHosts		=	0,
-			MissingInj			= 1
-		};
+    struct file_read_error : public base_error
+    {
+        file_read_error(std::string function, std::string file, int line) : base_error("File read not possible", function, file, line) {}
+        file_read_error(std::string msg, std::string function, std::string file, int line) : base_error(msg, function, file, line) { }
+    };
+    struct non_injectable_module_error : public base_error
+    {
+        enum class Type
+        {
+            MissingHosts = 0,
+            MissingInj   = 1
+        };
 
-		Type What;
-		std::string const FileName;
+        Type What;
+        std::string const FileName;
 
-		non_injectable_module_error(std::string function, std::string file, int line, std::string_view const& fileName, Type what) : base_error("Module (" + std::string(fileName) + ") not injectable", function, file, line), FileName(fileName), What(what) {}
-		non_injectable_module_error(std::string msg, std::string function, std::string file, int line, std::string_view const& fileName, Type what) : base_error(msg, function, file, line), FileName(fileName), What(what) { }
-	};
+        non_injectable_module_error(std::string function, std::string file, int line, std::string_view const& fileName, Type what) : base_error("Module (" + std::string(fileName) + ") not injectable", function, file, line), FileName(fileName), What(what) {}
+        non_injectable_module_error(std::string msg, std::string function, std::string file, int line, std::string_view const& fileName, Type what) : base_error(msg, function, file, line), FileName(fileName), What(what) { }
+    };
 
-	class Module final
-	{
-	public:
-		struct Host
-		{
-			std::string		const					FileName;
-			unsigned int	const					Checksum;
+    class Module final
+    {
+    public:
+        struct Host
+        {
+            std::string  const FileName;
+            unsigned int const Checksum;
 
-			Host() = default;
-			Host(std::string fileName, unsigned int checksum) : FileName(fileName), Checksum(checksum) {}
-		};
+            Host() = default;
+            Host(std::string fileName, unsigned int checksum) : FileName(fileName), Checksum(checksum) {}
+        };
 
-		string										FileName;
-		unsigned int								Checksum;
-		list<Hook>								Hooks;
-		list<Host>									Hosts;
-		// it's idea about Initialize(...) function concept, which invokes before main thread resumed or at moment when it's resumed. Invokcation not implemented. Just use hook at top of program.
-		InitFunction								InitFunction;
-	private:
-		HMODULE									_handle;
-		unique_ptr<HMODULE>				_injectorHandle;
-		std::ifstream								_ifs;
-		PECOFF::PortableExecutable		_pe;
+        string       FileName;
+        unsigned int Checksum;
+        list<Hook>   Hooks;
+        list<Host>   Hosts;
+        // it's idea about Initialize(...) function concept, which invokes before main thread resumed or at moment when it's resumed. Invokcation not implemented. Just use hook at top of program.
+        InitFunction InitFunction;
+    private:
+        HMODULE                    _handle;
+        unique_ptr<HMODULE>        _injectorHandle;
+        std::ifstream              _ifs;
+        PECOFF::PortableExecutable _pe;
 
-		void		parse_hosts();
-		void		parse_generic_hooks();
-		void		parse_extended_hooks();
-		void		parse_inj_file(string_view const& injFileName);
-	public:
-		std::istream&									stream()				{ return _ifs; }
-		PECOFF::PortableExecutable const&	pe()			const		{ return _pe; }
+        void parse_hosts();
+        void parse_generic_hooks();
+        void parse_extended_hooks();
+        void parse_inj_file(string_view const& injFileName);
+    public:
+        std::istream&                     stream()   { return _ifs; }
+        PECOFF::PortableExecutable const& pe() const { return _pe; }
 
-		Module() = default;
-		Module(string_view const& fileName);
-		Module(string_view const& fileName, string_view const& injFileName);
+        Module() = default;
+        Module(string_view const& fileName);
+        Module(string_view const& fileName, string_view const& injFileName);
 
-		void		parse(string_view const& fileName);
-		void		parse(string_view const& fileName, string_view const& injFileName);
+        void parse(string_view const& fileName);
+        void parse(string_view const& fileName, string_view const& injFileName);
 
-		bool		is_host_supported(string_view const& executableFile, unsigned int checksum = 0);
-		bool		is_executable_supported(string_view const& executableFile, unsigned int checksum = 0);
-		bool		handshake();
+        bool is_host_supported(string_view const& executableFile, unsigned int checksum = 0);
+        bool is_executable_supported(string_view const& executableFile, unsigned int checksum = 0);
+        bool handshake();
 
-		HMODULE		get_handle() const { return _handle; }
-		void				set_handle(HMODULE value) { _handle = value; }
+        HMODULE get_handle() const { return _handle; }
+        void    set_handle(HMODULE value) { _handle = value; }
 
-		HMODULE		get_injector_handle() const { return *_injectorHandle.get(); }
-		void				set_injector_handle(HMODULE value) { _injectorHandle = make_unique<HMODULE>(value); }
-	};
+        HMODULE get_injector_handle() const { return *_injectorHandle.get(); }
+        void    set_injector_handle(HMODULE value) { _injectorHandle = make_unique<HMODULE>(value); }
+    };
 }
 #endif //INJECTOR_MODULE_HPP

--- a/injector/module_retriever.cpp
+++ b/injector/module_retriever.cpp
@@ -2,63 +2,63 @@
 
 namespace Injector
 {
-	inline Address write_string(string str, VirtualMemoryHandle& vmh, size_t index)
-	{
-		vmh.Write(const_cast<char*>(str.c_str()), str.size() + 1, ModuleRetriever::LibraryNameLength * index);
-		return vmh.Pointer(ModuleRetriever::LibraryNameLength * index);
-	}
+    inline Address write_string(string str, VirtualMemoryHandle& vmh, size_t index)
+    {
+        vmh.Write(const_cast<char*>(str.c_str()), str.size() + 1, ModuleRetriever::LibraryNameLength * index);
+        return vmh.Pointer(ModuleRetriever::LibraryNameLength * index);
+    }
 
-	ModuleRetriever::ModuleRetriever(
-		ProcessMemory& memory,
-		Kernel32& kernel,
-		list<Module>& modules)	:
-			Memory(memory), Kernel(kernel),
-			Modules(modules)
-	{		
-		LoadLibraryFunction llFunc = reinterpret_cast<LoadLibraryFunction>(reinterpret_cast<BYTE*>(Kernel.LoadLibraryFunc));
-		//LoadLibraryFunction llFunc = reinterpret_cast<LoadLibraryFunction>(reinterpret_cast<BYTE*>(Kernel.LoadLibraryFunc) + imageOffset);
-		
-		LibNamesVmh = &Memory.Allocate(LibraryNameLength * Modules.size());
-		ModuleHandlesVmh = &Memory.Allocate(sizeof(HMODULE) * Modules.size());
-		
-		CodeBlocks.reserve(Modules.size());
-		
-		for (size_t index = 0; index < Modules.size(); ++index)
-		{				
-			Module& mdl = *std::next(Modules.begin(), index);
-			
-			size_t const libNameOffset = index * LibraryNameLength;
-			write_string(mdl.FileName, *LibNamesVmh, index);
+    ModuleRetriever::ModuleRetriever(
+        ProcessMemory& memory,
+        Kernel32& kernel,
+        list<Module>& modules) :
+            Memory(memory), Kernel(kernel),
+            Modules(modules)
+    {
+        LoadLibraryFunction llFunc = reinterpret_cast<LoadLibraryFunction>(reinterpret_cast<BYTE*>(Kernel.LoadLibraryFunc));
+        //LoadLibraryFunction llFunc = reinterpret_cast<LoadLibraryFunction>(reinterpret_cast<BYTE*>(Kernel.LoadLibraryFunc) + imageOffset);
 
-			Address const refLibName = LibNamesVmh->Pointer(libNameOffset);			
-			Address const refModuleHandle = ModuleHandlesVmh->Pointer(index * sizeof(HMODULE));
+        LibNamesVmh = &Memory.Allocate(LibraryNameLength * Modules.size());
+        ModuleHandlesVmh = &Memory.Allocate(sizeof(HMODULE) * Modules.size());
 
-			LoadLibraryCode& block = CodeBlocks.emplace_back(
-				static_cast<LPCSTR>(refLibName), 
-				llFunc, 
-				static_cast<HMODULE*>(refModuleHandle));
-		}
+        CodeBlocks.reserve(Modules.size());
 
-		size_t const codeSize = CodeBlocks.size() * sizeof(LoadLibraryCode);
-		size_t const base = PrefixCodeSize + codeSize;
-		size_t const programSize = base + PostfixCodeSize;
+        for (size_t index = 0; index < Modules.size(); ++index)
+        {
+            Module& mdl = *std::next(Modules.begin(), index);
 
-		BreakpointOffset = base + 2;
+            size_t const libNameOffset = index * LibraryNameLength;
+            write_string(mdl.FileName, *LibNamesVmh, index);
 
-		ProgramVmh = &Memory.Allocate(programSize);
-		ProgramVmh->Write(&PrxCode, PrefixCodeSize, 0);
-		ProgramVmh->Write(CodeBlocks.data(), codeSize, PrefixCodeSize);
-		ProgramVmh->Write(&PstxCode, PostfixCodeSize, base);
-	}
-	ModuleRetriever::~ModuleRetriever()
-	{
-		BreakpointOffset = 0;
+            Address const refLibName      = LibNamesVmh->Pointer(libNameOffset);
+            Address const refModuleHandle = ModuleHandlesVmh->Pointer(index * sizeof(HMODULE));
 
-		Memory.Free(*ProgramVmh);
-		Memory.Free(*ModuleHandlesVmh);
-		Memory.Free(*LibNamesVmh);
-	}
+            LoadLibraryCode& block = CodeBlocks.emplace_back(
+                static_cast<LPCSTR>(refLibName),
+                llFunc, 
+                static_cast<HMODULE*>(refModuleHandle));
+        }
 
-	Address ModuleRetriever::breakpoint() const { return ProgramVmh->Pointer(BreakpointOffset); }
-	Address ModuleRetriever::instruction() const { return ProgramVmh->Pointer(); }
+        size_t const codeSize    = CodeBlocks.size() * sizeof(LoadLibraryCode);
+        size_t const base        = PrefixCodeSize + codeSize;
+        size_t const programSize = base + PostfixCodeSize;
+
+        BreakpointOffset = base + 2;
+
+        ProgramVmh = &Memory.Allocate(programSize);
+        ProgramVmh->Write(&PrxCode, PrefixCodeSize, 0);
+        ProgramVmh->Write(CodeBlocks.data(), codeSize, PrefixCodeSize);
+        ProgramVmh->Write(&PstxCode, PostfixCodeSize, base);
+    }
+    ModuleRetriever::~ModuleRetriever()
+    {
+        BreakpointOffset = 0;
+
+        Memory.Free(*ProgramVmh);
+        Memory.Free(*ModuleHandlesVmh);
+        Memory.Free(*LibNamesVmh);
+    }
+
+    Address ModuleRetriever::breakpoint() const { return ProgramVmh->Pointer(BreakpointOffset); }
+    Address ModuleRetriever::instruction() const { return ProgramVmh->Pointer(); }
 }

--- a/injector/typedefs.hpp
+++ b/injector/typedefs.hpp
@@ -5,48 +5,48 @@
 
 #include <string>
 
-using Address							= void*;
-using RegistersPtr					= void*;
-using cstring							= const char*;
+using Address      = void*;
+using RegistersPtr = void*;
+using cstring      = const char*;
 
 namespace Injector
 {
 #pragma pack(push, 1)
-	struct HandshakeInfo
-	{
-		int									cbSize;
-		int									num_hooks;
-		unsigned int					checksum;
-		DWORD							exeFilesize;
-		DWORD							exeTimestamp;
-		unsigned int					exeCRC;
-		int									cchMessage;
-		char* Message;
-	};
+    struct HandshakeInfo
+    {
+        int          cbSize;
+        int          num_hooks;
+        unsigned int checksum;
+        DWORD        exeFilesize;
+        DWORD        exeTimestamp;
+        unsigned int exeCRC;
+        int          cchMessage;
+        char*        Message;
+    };
 
-	struct HandshakeResult
-	{
-		bool								Success;
-		HRESULT						Code;
-		char* Message;
-	};
+    struct HandshakeResult
+    {
+        bool    Success;
+        HRESULT Code;
+        char*   Message;
+    };
 
-	struct InjectionContext
-	{
-		cstring			Executable;
-		cstring			Arguments;
+    struct InjectionContext
+    {
+        cstring Executable;
+        cstring Arguments;
 
-		size_t			ModuleCount;
-		HMODULE*	ModuleHandles;
-		cstring			ModuleNames;
-		size_t			NameStepLength;
-	};
+        size_t   ModuleCount;
+        HMODULE* ModuleHandles;
+        cstring  ModuleNames;
+        size_t   NameStepLength;
+    };
 #pragma pack(pop)
 
-	using HookFunction				= DWORD(__cdecl*)(RegistersPtr registers);
-	using InitFunction					= DWORD(__cdecl*)(Injector::InjectionContext* pInjectionContext);
-	
-	using HandshakeFunction		= HRESULT(__cdecl* )(Injector::HandshakeInfo* pHandshakeInfo);
-}	
+    using HookFunction      = DWORD(__cdecl*)(RegistersPtr registers);
+    using InitFunction      = DWORD(__cdecl*)(Injector::InjectionContext* pInjectionContext);
+
+    using HandshakeFunction = HRESULT(__cdecl* )(Injector::HandshakeInfo* pHandshakeInfo);
+}    
 
 #endif //INJECTOR_TYPEDEFS_HPP

--- a/injector/waiter.hpp
+++ b/injector/waiter.hpp
@@ -8,28 +8,28 @@
 
 namespace Injector
 {
-	static constexpr size_t WaiterBreakpointOffset = 2;
-	
-	BYTE const WaiterCodeData[] =
-	{
-		NOP,
-		NOP,
-		DEBUGGER_INTERRUPT_CODE, NOP
-	};
-	static constexpr size_t WaiterCodeDataSize = sizeof(WaiterCodeData);	
-	#pragma pack(push, 1)
-	struct WaiterCode
-	{
-		BYTE arr1[4] { 0, 0, 0, 0 };
+    static constexpr size_t WaiterBreakpointOffset = 2;
 
-		WaiterCode()
-		{
-			memcpy(this, &WaiterCodeData, WaiterCodeDataSize);
-		}
-	};
-	static constexpr size_t WaiterCodeSize = sizeof(WaiterCode);
-	#pragma pack(pop)
-	static_assert(WaiterCodeDataSize == WaiterCodeSize, "The code and data are not equals");
+    BYTE const WaiterCodeData[] =
+    {
+        NOP,
+        NOP,
+        DEBUGGER_INTERRUPT_CODE, NOP
+    };
+    static constexpr size_t WaiterCodeDataSize = sizeof(WaiterCodeData);
+    #pragma pack(push, 1)
+    struct WaiterCode
+    {
+        BYTE arr1[4] { 0, 0, 0, 0 };
+
+        WaiterCode()
+        {
+            memcpy(this, &WaiterCodeData, WaiterCodeDataSize);
+        }
+    };
+    static constexpr size_t WaiterCodeSize = sizeof(WaiterCode);
+    #pragma pack(pop)
+    static_assert(WaiterCodeDataSize == WaiterCodeSize, "The code and data are not equals");
 }
 
 #endif //INJECTOR_WIATER_HPP

--- a/syringe/main.cpp
+++ b/syringe/main.cpp
@@ -14,240 +14,240 @@ using namespace Injector;
 using namespace PECOFF;
 
 int ParseModule(
-	Module& mdl, 
-	bool forceExecutableValidation,
-	bool stopIfModuleInvalid)
+    Module& mdl, 
+    bool forceExecutableValidation,
+    bool stopIfModuleInvalid)
 {
-	try
-	{
-		mdl.parse(mdl.FileName);
-		spdlog::info("::\"{0}\": {1} hooks & {2} hosts found, checksum: 0x{3:x} ({3:d})", mdl.FileName, mdl.Hooks.size(), mdl.Hosts.size(), mdl.Checksum);
-		for (auto& host : mdl.Hosts)
-			spdlog::trace(":::: 0x{1:x}, \"{0}\"", host.FileName, host.Checksum);
-	}
-	catch (file_not_found_error const& ex)
-	{
-		auto msg = Utilities::string_format("File not found: \"%s\".", ex.FileName.c_str());
-		spdlog::error("::\"{}\": File not found.", ex.FileName);
-		if (stopIfModuleInvalid)
-		{
-			MessageBoxA(
-				nullptr,
-				msg.c_str(),
-				"Invalid configuration.",
-				MB_OK);
-			return EXIT_FAILURE;
-		}
-	}
-	catch (non_injectable_module_error const& ex)
-	{
-		auto msg = Utilities::string_format("Couldn't inject dll: %s.\nThis is not injectable.", ex.FileName.c_str());
-		spdlog::error("::\"{}\": not injectable.", ex.FileName);
-		if (stopIfModuleInvalid)
-		{
-			MessageBoxA(
-				nullptr,
-				msg.c_str(),
-				"Invalid configuration.",
-				MB_OK);
-			return EXIT_FAILURE;
-		}
-	}
-	catch (executable_not_supported_error const& ex)
-	{
-		auto msg = Utilities::string_format("Couldn't inject dll: %s.\Executable not supported by module.\nYou can disable '-forceExecutableValidation' to skip checking.", ex.FileName.c_str());
-		spdlog::error("::\"{}\": executable not supported.", ex.FileName);
-		if (stopIfModuleInvalid) 
-		{
-			MessageBoxA(
-				nullptr,
-				msg.c_str(),
-				"Invalid configuration.",
-				MB_OK);
-			return EXIT_FAILURE;
-		}
-	}
-	catch (const file_read_error& ex)
-	{
-		auto msg = Utilities::string_format("File not found/not readable: %s.", mdl.FileName.c_str());
-		spdlog::error("::\"{}\": File not found/not readable", mdl.FileName);
-		if (stopIfModuleInvalid)
-		{
-			MessageBoxA(
-				nullptr,
-				msg.c_str(),
-				"Invalid configuration.",
-				MB_OK);
-			return EXIT_FAILURE;
-		}
-	}
-	return EXIT_SUCCESS;
+    try
+    {
+        mdl.parse(mdl.FileName);
+        spdlog::info("::\"{0}\": {1} hooks & {2} hosts found, checksum: 0x{3:x} ({3:d})", mdl.FileName, mdl.Hooks.size(), mdl.Hosts.size(), mdl.Checksum);
+        for (auto& host : mdl.Hosts)
+            spdlog::trace(":::: 0x{1:x}, \"{0}\"", host.FileName, host.Checksum);
+    }
+    catch (file_not_found_error const& ex)
+    {
+        auto msg = Utilities::string_format("File not found: \"%s\".", ex.FileName.c_str());
+        spdlog::error("::\"{}\": File not found.", ex.FileName);
+        if (stopIfModuleInvalid)
+        {
+            MessageBoxA(
+                nullptr,
+                msg.c_str(),
+                "Invalid configuration.",
+                MB_OK);
+            return EXIT_FAILURE;
+        }
+    }
+    catch (non_injectable_module_error const& ex)
+    {
+        auto msg = Utilities::string_format("Couldn't inject dll: %s.\nThis is not injectable.", ex.FileName.c_str());
+        spdlog::error("::\"{}\": not injectable.", ex.FileName);
+        if (stopIfModuleInvalid)
+        {
+            MessageBoxA(
+                nullptr,
+                msg.c_str(),
+                "Invalid configuration.",
+                MB_OK);
+            return EXIT_FAILURE;
+        }
+    }
+    catch (executable_not_supported_error const& ex)
+    {
+        auto msg = Utilities::string_format("Couldn't inject dll: %s.\Executable not supported by module.\nYou can disable '-forceExecutableValidation' to skip checking.", ex.FileName.c_str());
+        spdlog::error("::\"{}\": executable not supported.", ex.FileName);
+        if (stopIfModuleInvalid) 
+        {
+            MessageBoxA(
+                nullptr,
+                msg.c_str(),
+                "Invalid configuration.",
+                MB_OK);
+            return EXIT_FAILURE;
+        }
+    }
+    catch (const file_read_error& ex)
+    {
+        auto msg = Utilities::string_format("File not found/not readable: %s.", mdl.FileName.c_str());
+        spdlog::error("::\"{}\": File not found/not readable", mdl.FileName);
+        if (stopIfModuleInvalid)
+        {
+            MessageBoxA(
+                nullptr,
+                msg.c_str(),
+                "Invalid configuration.",
+                MB_OK);
+            return EXIT_FAILURE;
+        }
+    }
+    return EXIT_SUCCESS;
 }
 
 int ParseModules(
-	list<Module>& modules, 
-	bool forceExecutableValidation,
-	bool processWithEmptyModules,
-	bool stopIfModuleInvalid)
+    list<Module>& modules, 
+    bool forceExecutableValidation,
+    bool processWithEmptyModules,
+    bool stopIfModuleInvalid)
 {
-	if (modules.empty() && !processWithEmptyModules)
-	{
-		spdlog::error("No modules to inject.");
-		MessageBoxA(
-			nullptr,
-			"No modules to inject.",
-			"Invalid configuration.",
-			MB_OK);
-		return EXIT_FAILURE;
-	}
-	list<Module*> notAccepted;
-	for (auto& mdl : modules)
-	{
-		auto r = ParseModule(mdl, forceExecutableValidation, stopIfModuleInvalid);
-		if (r != EXIT_SUCCESS)
-		{
-			notAccepted.push_back(&mdl);
-			if (stopIfModuleInvalid)
-				return r;
-		}
-	}
-	for (auto& mdl : notAccepted)
-		modules.remove_if([&](Module& a) -> bool { return a.FileName == mdl->FileName; });
+    if (modules.empty() && !processWithEmptyModules)
+    {
+        spdlog::error("No modules to inject.");
+        MessageBoxA(
+            nullptr,
+            "No modules to inject.",
+            "Invalid configuration.",
+            MB_OK);
+        return EXIT_FAILURE;
+    }
+    list<Module*> notAccepted;
+    for (auto& mdl : modules)
+    {
+        auto r = ParseModule(mdl, forceExecutableValidation, stopIfModuleInvalid);
+        if (r != EXIT_SUCCESS)
+        {
+            notAccepted.push_back(&mdl);
+            if (stopIfModuleInvalid)
+                return r;
+        }
+    }
+    for (auto& mdl : notAccepted)
+        modules.remove_if([&](Module& a) -> bool { return a.FileName == mdl->FileName; });
 
-	return EXIT_SUCCESS;
+    return EXIT_SUCCESS;
 }
 
 int Run(std::string_view const arguments)
 {
-	auto file_logger = spdlog::basic_logger_mt("file-logger", "syringe.log", true);
+    auto file_logger = spdlog::basic_logger_mt("file-logger", "syringe.log", true);
 
-	spdlog::set_pattern("%v");
-	spdlog::set_level(spdlog::level::trace);
-	spdlog::set_default_logger(file_logger);
+    spdlog::set_pattern("%v");
+    spdlog::set_level(spdlog::level::trace);
+    spdlog::set_default_logger(file_logger);
 
-	spdlog::trace("Command line: '{}'", arguments);
+    spdlog::trace("Command line: '{}'", arguments);
 
-	string					executableFile;
-	list<Module>			modules; 
-	bool						forceExecutableValidation	= false;
-	bool						processWithEmptyModules	= true;
-	bool						stopIfModuleInvalid			= false;
+    string       executableFile;
+    list<Module> modules; 
+    bool         forceExecutableValidation = false;
+    bool         processWithEmptyModules   = true;
+    bool         stopIfModuleInvalid       = false;
 
-	unsigned int			executableChecksum			= 0;
+    unsigned int executableChecksum        = 0;
 
-	try
-	{
-		ArgumentMap* map = ParseArguments(const_cast<TCHAR*>(arguments.data()));
-		if (!map->HasFreeParameters())
-		{
-			spdlog::error("Executable path not specified. It MUST be first parameter of command line.");
-			MessageBoxA(
-				nullptr,
-				"First argument must be executable file path.",
-				"Invalid configuration.",
-				MB_OK);
-			return EXIT_FAILURE;
-		}
-		executableFile = map->FreeParameters()->Parameters[0];
+    try
+    {
+        ArgumentMap* map = ParseArguments(const_cast<TCHAR*>(arguments.data()));
+        if (!map->HasFreeParameters())
+        {
+            spdlog::error("Executable path not specified. It MUST be first parameter of command line.");
+            MessageBoxA(
+                nullptr,
+                "First argument must be executable file path.",
+                "Invalid configuration.",
+                MB_OK);
+            return EXIT_FAILURE;
+        }
+        executableFile = map->FreeParameters()->Parameters[0];
 
-		executableChecksum = CRC32::compute_stream(file_open_binary(executableFile));
-		spdlog::info("Executable \"{0}\", checksum: 0x{1:x} ({1:d})", executableFile, executableChecksum);
+        executableChecksum = CRC32::compute_stream(file_open_binary(executableFile));
+        spdlog::info("Executable \"{0}\", checksum: 0x{1:x} ({1:d})", executableFile, executableChecksum);
 
-		size_t moduleCount = 0;
-		for (size_t i = 0; i < map->Count(); i++)
-		{
-			auto	arg	= map->At(i);
-			if ((string) arg->Prefix == (string) "-forceExecutableValidation")
-				forceExecutableValidation = true;
-			else if ((string) arg->Prefix == (string)"-requireInjectableModules")
-				processWithEmptyModules = false;
-			else if ((string) arg->Prefix == (string)"-requireValidConfiguration")
-				stopIfModuleInvalid = true;
-			else if ((string) arg->Prefix == (string) "-dll")
-				moduleCount++;
-		}
+        size_t moduleCount = 0;
+        for (size_t i = 0; i < map->Count(); i++)
+        {
+            auto    arg    = map->At(i);
+            if ((string) arg->Prefix == (string) "-forceExecutableValidation")
+                forceExecutableValidation = true;
+            else if ((string) arg->Prefix == (string)"-requireInjectableModules")
+                processWithEmptyModules = false;
+            else if ((string) arg->Prefix == (string)"-requireValidConfiguration")
+                stopIfModuleInvalid = true;
+            else if ((string) arg->Prefix == (string) "-dll")
+                moduleCount++;
+        }
 
-		if (moduleCount > 0)
-		{
-			spdlog::info("Modules to inject was directly specified:");
+        if (moduleCount > 0)
+        {
+            spdlog::info("Modules to inject was directly specified:");
 
-			modules.resize(moduleCount);
+            modules.resize(moduleCount);
 
-			moduleCount = 0;
-			for (size_t i = 0; i < map->Count(); i++)
-			{
-				auto	arg = map->At(i);
-				if ((string) arg->Prefix != (string) "-dll")
-					continue;
+            moduleCount = 0;
+            for (size_t i = 0; i < map->Count(); i++)
+            {
+                auto    arg = map->At(i);
+                if ((string) arg->Prefix != (string) "-dll")
+                    continue;
 
-				auto fn = arg->Parameters[0];
-				std::next(modules.begin(), moduleCount)->FileName = fn;
-				moduleCount++;
-			}
-		}
-		else
-		{
-			spdlog::info("Modules to inject not specified, scan directory (\"{0}\"):", std::filesystem::current_path().string());
+                auto fn = arg->Parameters[0];
+                std::next(modules.begin(), moduleCount)->FileName = fn;
+                moduleCount++;
+            }
+        }
+        else
+        {
+            spdlog::info("Modules to inject not specified, scan directory (\"{0}\"):", std::filesystem::current_path().string());
 
-			for (const auto& e : std::filesystem::directory_iterator(std::filesystem::current_path()))
-			{
-				if (!e.is_regular_file())
-					continue;
-				if (e.path().has_extension() && e.path().extension().string() == (string)".dll")
-				{
-					auto& mdl			= modules.emplace_back();
-					mdl.FileName		= e.path().filename().string();
-				}
-			}
-		}		
+            for (const auto& e : std::filesystem::directory_iterator(std::filesystem::current_path()))
+            {
+                if (!e.is_regular_file())
+                    continue;
+                if (e.path().has_extension() && e.path().extension().string() == (string)".dll")
+                {
+                    auto& mdl    = modules.emplace_back();
+                    mdl.FileName = e.path().filename().string();
+                }
+            }
+        }        
 
-		for(auto& mdl : modules)
-			spdlog::info("::\"{0}\"", mdl.FileName);
+        for(auto& mdl : modules)
+            spdlog::info("::\"{0}\"", mdl.FileName);
 
-		spdlog::info("Parse modules for hosts & hooks");
-		auto r = ParseModules(modules, forceExecutableValidation, processWithEmptyModules, stopIfModuleInvalid);
-		if (r != EXIT_SUCCESS)
-			return r;
-	}
-	catch (ArgumentMap::StringIsEmptyException& ex)
-	{
-		MessageBoxA(
-			nullptr,
-			"Couldn't parse arguments: string is empty.",
-			"Invalid configuration.",
-			MB_OK);
-		return EXIT_FAILURE;
-	}	
-	
-	PortableExecutable peExecutable { file_open_binary(executableFile) };
-	Kernel32 kernel { peExecutable };
-	if(!kernel.is_injectable())
-	{
-		MessageBoxA(
-			nullptr, 
-			"Import section does not contains KERNEL32.DLL with LOADLIBRARYA, GETPROCADDRESS, FREELIBRARY functions.", 
-			"Not injectable.",
-			MB_OK);		
-		return EXIT_FAILURE;
-	}
+        spdlog::info("Parse modules for hosts & hooks");
+        auto r = ParseModules(modules, forceExecutableValidation, processWithEmptyModules, stopIfModuleInvalid);
+        if (r != EXIT_SUCCESS)
+            return r;
+    }
+    catch (ArgumentMap::StringIsEmptyException& ex)
+    {
+        MessageBoxA(
+            nullptr,
+            "Couldn't parse arguments: string is empty.",
+            "Invalid configuration.",
+            MB_OK);
+        return EXIT_FAILURE;
+    }    
 
-	spdlog::info("Prepare debugger & process...");
-	Debugger::DebugLoop debugger { executableFile, arguments, /* We do not want to lost all applies after debugger detach (by other, real debugger, attaching) */ false };
-	spdlog::info("Prepare configurator...");
-	Configurator configurator { peExecutable, debugger, /*kernel,*/ modules, arguments, executableFile};
-	spdlog::info("Run debugger...");
-	debugger.Run();
-	spdlog::info("Injector & debugger done.");
-	return EXIT_SUCCESS;
+    PortableExecutable peExecutable { file_open_binary(executableFile) };
+    Kernel32 kernel { peExecutable };
+    if(!kernel.is_injectable())
+    {
+        MessageBoxA(
+            nullptr, 
+            "Import section does not contains KERNEL32.DLL with LOADLIBRARYA, GETPROCADDRESS, FREELIBRARY functions.", 
+            "Not injectable.",
+            MB_OK);        
+        return EXIT_FAILURE;
+    }
+
+    spdlog::info("Prepare debugger & process...");
+    Debugger::DebugLoop debugger { executableFile, arguments, /* We do not want to lost all applies after debugger detach (by other, real debugger, attaching) */ false };
+    spdlog::info("Prepare configurator...");
+    Configurator configurator { peExecutable, debugger, /*kernel,*/ modules, arguments, executableFile};
+    spdlog::info("Run debugger...");
+    debugger.Run();
+    spdlog::info("Injector & debugger done.");
+    return EXIT_SUCCESS;
 }
 
 int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow)
 {
-	UNREFERENCED_PARAMETER(hInstance);
-	UNREFERENCED_PARAMETER(hPrevInstance);
-	UNREFERENCED_PARAMETER(nCmdShow);
+    UNREFERENCED_PARAMETER(hInstance);
+    UNREFERENCED_PARAMETER(hPrevInstance);
+    UNREFERENCED_PARAMETER(nCmdShow);
 
-	std::string args = lpCmdLine;
+    std::string args = lpCmdLine;
 
-	return Run(args);
+    return Run(args);
 }


### PR DESCRIPTION
Original code impossible to read normally due to forcing of tabs use instead of spaces, even between words. So I replaced all tabs with spaces and added some spacing in variable declarations.

[Before](https://github.com/MahBoiDeveloper/Syringe/blob/master/debugger/debugger.hpp#L29):
![image](https://github.com/Phobos-developers/Syringe/assets/61310813/939b3bb6-bdfd-49d0-8e0b-2e6d30bdc004)

[After](https://github.com/MahBoiDeveloper/Syringe/blob/fix/ReplaceTabsToSpaces/debugger/debugger.hpp#L29):
![image](https://github.com/Phobos-developers/Syringe/assets/61310813/f19de8c7-41e3-4208-8b3f-04e77ea6408b)
