### PR TITLE
Change command line format

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -6,8 +6,28 @@
 #include <string>
 
 #include <commctrl.h>
+#include <shellapi.h>
 
-int Run(std::string_view const arguments)
+std::vector<std::string> GetArguments()
+{
+    // Get argc, argv in wide chars
+    int argc = 0;
+    LPWSTR* argvW = CommandLineToArgvW(GetCommandLineW(), &argc);
+
+    // Convert to UTF-8. Skip the first argument as it contains the path to Syringe itself
+    std::vector<std::string> argv(argc - 1);
+    for (int i = 1; i < argc; ++i) {
+        int len = WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, nullptr, 0, nullptr, nullptr);
+        argv[i - 1].resize(len - 1);
+        WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, argv[i - 1].data(), len, nullptr, nullptr);
+    }
+
+    LocalFree(argvW);
+
+    return argv;
+}
+
+int Run(const std::vector<std::string>& arguments)
 {
     constexpr auto const VersionString = "SyringeEx " SYRINGEEX_VER_TEXT ", based on Syringe 0.7.2.0";
 
@@ -25,14 +45,14 @@ int Run(std::string_view const arguments)
 
     try
     {
-        auto const command = get_command_line(arguments);
+        auto const command = parse_command_line(arguments);
 
         Log::WriteLine(
             "WinMain: Trying to load executable file \"%.*s\"...",
-            printable(command.executable));
+            printable(command.executable_name));
         Log::WriteLine();
 
-        SyringeDebugger Debugger{ command.executable, command.flags };
+        SyringeDebugger Debugger{ command.executable_name, command.syringe_arguments };
         failure = "Could not run executable.";
 
         Log::WriteLine("WinMain: SyringeDebugger::FindDLLs();");
@@ -41,10 +61,10 @@ int Run(std::string_view const arguments)
 
         Log::WriteLine(
             "WinMain: SyringeDebugger::Run(\"%.*s\");",
-            printable(command.arguments));
+            printable(command.game_arguments));
         Log::WriteLine();
 
-        Debugger.Run(command.arguments);
+        Debugger.Run(command.game_arguments);
         Log::WriteLine("WinMain: SyringeDebugger::Run finished.");
         Log::WriteLine("WinMain: Exiting on success.");
         return ERROR_SUCCESS;
@@ -80,7 +100,8 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 {
     UNREFERENCED_PARAMETER(hInstance);
     UNREFERENCED_PARAMETER(hPrevInstance);
+    UNREFERENCED_PARAMETER(lpCmdLine);
     UNREFERENCED_PARAMETER(nCmdShow);
 
-    return Run(lpCmdLine);
+    return Run(GetArguments());
 }

--- a/Main.cpp
+++ b/Main.cpp
@@ -84,7 +84,7 @@ int Run(const std::vector<std::string>& arguments)
     {
         MessageBoxA(
             nullptr, "Syringe cannot be run like that.\n\n"
-            "Usage:\nSyringe.exe [-i=<injectedfile.dll> ...] \"<exe name>\" <arguments>",
+            "Usage:\nSyringe.exe <exe name> [-i=<injectedfile.dll> ...] [--args=\"<arguments>\"]",
             VersionString, MB_OK | MB_ICONINFORMATION);
 
         Log::WriteLine(

--- a/Main.cpp
+++ b/Main.cpp
@@ -16,7 +16,8 @@ std::vector<std::string> GetArguments()
 
     // Convert to UTF-8. Skip the first argument as it contains the path to Syringe itself
     std::vector<std::string> argv(argc - 1);
-    for (int i = 1; i < argc; ++i) {
+    for (int i = 1; i < argc; ++i)
+    {
         int len = WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, nullptr, 0, nullptr, nullptr);
         argv[i - 1].resize(len - 1);
         WideCharToMultiByte(CP_UTF8, 0, argvW[i], -1, argv[i - 1].data(), len, nullptr, nullptr);

--- a/README.md
+++ b/README.md
@@ -1,14 +1,53 @@
-# Syringe
+# SyringeEx
 
-A program to inject DLLs containing C++ code via hooks into a running process, allowing for the execution of custom code within that process. Based on the original Syringe project, it is being extended to support more features.
-
+SyringeEx is a DLL injection and runtime hooking loader that launches a target executable and injects one or more hook DLLs into it.  
+This fork extends and modernizes the original **Syringe** while maintaining compatibility with existing tooling and mods.
 
 # License
 
-- File [Syringe.h](Syringe.h) is an *API header* as [LGPLv3](LICENSE) decribes.
+The **entire program** is licensed under **LGPLv3**.  
+See [`LICENSE`](LICENSE) for details.
 
----
+The file **[`Syringe.h`](Syringe.h)** is explicitly designated as an **API header**, and may be used under the LGPLv3 interface rules.
 
-The original codebase ("Syringe") for this project was created by Patrick "pd" Dinklage, based in part on code written by Jan Newger. It was then maintained and worked on by Ares contributors.
+# Background
 
-The original location of this work is [HERE](http://forums.renegadeprojects.com/showthread.php?tid=1160&pid=13088#pid13088).
+Syringe was originally created by **Patrick "pd" Dinklage**, based partially on work by **Jan Newger**, and later maintained by contributors from the **Ares** project.
+
+The original discussion thread is available [here](http://forums.renegadeprojects.com/showthread.php?tid=1160&pid=13088#pid13088).
+
+# Command-Line Usage
+
+### Executable Selection
+
+The **first argument not starting with `-`** is treated as the executable to launch:
+
+```
+syringe.exe game.exe
+```
+
+### Passing Arguments to the Target Executable
+
+Use `--args="..."` to provide arguments for the launched process:
+
+```
+syringe.exe game.exe --args="-CD. -SPAWN"
+```
+
+### DLL Injection Behavior
+
+By default, Syringe injects **all compatible DLLs** found in the directory.
+
+To load only specific DLLs, use one or more instances of:
+
+```
+-i=<dllname.dll>
+```
+
+Example:
+
+```
+syringe.exe game.exe -i=ExtensionA.dll -i=ExtensionB.dll
+```
+
+When at least one `-i=` option is present, **only the specified DLLs** are injected.

--- a/Support.h
+++ b/Support.h
@@ -45,8 +45,8 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
 
     for (const auto& arg : arguments)
     {
-        // executable name: first argument not starting with '--'
-        if (!exe_found && !arg.starts_with("--"))
+        // executable name: first argument not starting with '-'
+        if (!exe_found && !arg.starts_with("-"))
         {
             exe_found = true;
             ret.executable_name = arg;

--- a/Support.h
+++ b/Support.h
@@ -28,6 +28,8 @@ inline auto trim(std::string_view string) noexcept
 
 inline auto parse_command_line(const std::vector<std::string>& arguments)
 {
+    static constexpr std::string_view ARGS_FLAG = "--args=";
+
     struct argument_set
     {
         std::vector<std::string> syringe_arguments;
@@ -54,10 +56,10 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
         }
 
         // game arguments: --args="blob"
-        if (arg.starts_with("--args="))
+        if (arg.starts_with(ARGS_FLAG))
         {
             // extract after --args=
-            std::string blob = arg.substr(std::size("--args=")-1);
+            std::string blob = arg.substr(ARGS_FLAG.size());
             ret.game_arguments = blob;
             continue;
         }

--- a/SyringeDebugger.h
+++ b/SyringeDebugger.h
@@ -28,24 +28,21 @@ class SyringeDebugger
     static constexpr std::string_view INCLUDE_FLAG = "-i=";
 
 public:
-    SyringeDebugger(std::string_view filename, std::string_view flags = "")
+    SyringeDebugger(std::string_view filename, std::vector<std::string> flags = {})
         : exe(filename)
     {
         // parse all -i=filename_to_inject from flags
-        for (auto const flag : std::views::split(flags, " "sv))
+        for (auto const& flag : flags)
         {
             auto const flagView = std::string_view{ flag.begin(), flag.end() };
             auto const pos = flagView.find(INCLUDE_FLAG);
             if (pos != std::string_view::npos)
             {
-                dlls.emplace_back(std::string{ flagView.begin() + pos + INCLUDE_FLAG.size(),
-                                              flagView.end() });
+                dlls.emplace_back(flagView.begin() + pos + INCLUDE_FLAG.size(), flagView.end());
             }
             else
             {
-                Log::WriteLine(
-                    __FUNCTION__ ": Unknown flag \"%.*s\", skipping.",
-                    printable(flagView));
+                Log::WriteLine(__FUNCTION__ ": Unknown flag \"%.*s\", skipping.", printable(flagView));
             }
         }
 


### PR DESCRIPTION
Changes the command line format.
The new format is `syringe.exe game.exe --arg1 --arg2 --arg3 --args="-gamearg1 -gamearg2"`
None of the arguments are positional, the first argument without -- is treated as the executable name.
`--args` is a single argument whose contents are passed to the game.