### PR TITLE
Refactor CLI argument parsing to use `--` delimiter

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -1,4 +1,4 @@
-#include "Log.h"
+﻿#include "Log.h"
 #include "SyringeDebugger.h"
 #include "Support.h"
 #include "resource.h"
@@ -14,32 +14,70 @@ struct Arguments
     std::string game_args;
 };
 
+// Find position of the separator token "--" (token-aware).
+// Returns the index of the whitespace BEFORE "--", or npos if not found.
+//
+// This implementation:
+// - Tracks quotes using correct Windows rules (backslash counting)
+// - Ensures "--" is a standalone token
+// - Avoids false matches inside quotes
 size_t FindSeparator(const std::wstring& cmdLine)
 {
     bool inQuotes = false;
-    size_t len = cmdLine.length();
+    const size_t len = cmdLine.length();
+
     for (size_t i = 0; i < len; ++i)
     {
-        if (cmdLine[i] == L'\\' && i + 1 < len && cmdLine[i + 1] == L'"')
-        {
-            i += 1;
-            continue;
-        }
-        
+        // ------------------------------------------------------------
+        // Handle quote with Windows backslash rules
+        // ------------------------------------------------------------
         if (cmdLine[i] == L'"')
         {
-            inQuotes = !inQuotes;
+            // Count consecutive backslashes before the quote
+            size_t backslashCount = 0;
+            for (size_t j = i; j > 0 && cmdLine[j - 1] == L'\\'; --j)
+            {
+                backslashCount++;
+            }
+
+            // Even => delimiter, Odd => escaped
+            if ((backslashCount % 2) == 0)
+            {
+                inQuotes = !inQuotes;
+            }
+
             continue;
         }
-        
-        if (!inQuotes && cmdLine[i] == L' ')
+
+        // ------------------------------------------------------------
+        // Only check for separator outside quotes
+        // ------------------------------------------------------------
+        if (!inQuotes && iswspace(cmdLine[i]))
         {
-            if (i + 3 < len && cmdLine[i + 1] == L'-' && cmdLine[i + 2] == L'-' && cmdLine[i + 3] == L' ')
+            // Skip whitespace to find next token start
+            size_t j = i;
+            while (j < len && iswspace(cmdLine[j]))
             {
-                return i;
+                j++;
+            }
+
+            // Check for "--"
+            if (j + 1 < len &&
+                cmdLine[j] == L'-' &&
+                cmdLine[j + 1] == L'-')
+            {
+                size_t k = j + 2;
+
+                // Ensure it's a standalone token:
+                // must end or be followed by whitespace
+                if (k == len || iswspace(cmdLine[k]))
+                {
+                    return i; // position before separator
+                }
             }
         }
     }
+
     return std::wstring::npos;
 }
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -84,7 +84,7 @@ int Run(const std::vector<std::string>& arguments)
     {
         MessageBoxA(
             nullptr, "Syringe cannot be run like that.\n\n"
-            "Usage:\nSyringe.exe <exe name> [-i=<injectedfile.dll> ...] [--args=\"<arguments>\"]",
+            "Usage:\nSyringe.exe <exe name> [-i=<injectedfile.dll> ...] [-- <arguments>]",
             VersionString, MB_OK | MB_ICONINFORMATION);
 
         Log::WriteLine(

--- a/Main.cpp
+++ b/Main.cpp
@@ -8,11 +8,61 @@
 #include <commctrl.h>
 #include <shellapi.h>
 
-std::vector<std::string> GetArguments()
+struct Arguments
 {
+    std::vector<std::string> syringe_args;
+    std::string game_args;
+};
+
+size_t FindSeparator(const std::wstring& cmdLine)
+{
+    bool inQuotes = false;
+    size_t len = cmdLine.length();
+    for (size_t i = 0; i < len; ++i)
+    {
+        if (cmdLine[i] == L'\\' && i + 1 < len && cmdLine[i + 1] == L'"')
+        {
+            i += 1;
+            continue;
+        }
+        
+        if (cmdLine[i] == L'"')
+        {
+            inQuotes = !inQuotes;
+            continue;
+        }
+        
+        if (!inQuotes && cmdLine[i] == L' ')
+        {
+            if (i + 3 < len && cmdLine[i + 1] == L'-' && cmdLine[i + 2] == L'-' && cmdLine[i + 3] == L' ')
+            {
+                return i;
+            }
+        }
+    }
+    return std::wstring::npos;
+}
+
+Arguments GetArguments()
+{
+    std::wstring wszSyringeArgs;
+    std::wstring wszGameArgs;
+    std::wstring lpCmdLine = GetCommandLineW();
+    auto separator = FindSeparator(lpCmdLine);
+    if (separator != std::wstring::npos)
+    {
+        wszSyringeArgs = lpCmdLine.substr(0, separator);
+        wszGameArgs = lpCmdLine.substr(separator + 4);
+    }
+    else
+    {
+        wszSyringeArgs = lpCmdLine;
+        wszGameArgs = L"";
+    }
+
     // Get argc, argv in wide chars
     int argc = 0;
-    LPWSTR* argvW = CommandLineToArgvW(GetCommandLineW(), &argc);
+    LPWSTR* argvW = CommandLineToArgvW(wszSyringeArgs.c_str(), &argc);
 
     // Convert to UTF-8. Skip the first argument as it contains the path to Syringe itself
     std::vector<std::string> argv(argc - 1);
@@ -25,10 +75,17 @@ std::vector<std::string> GetArguments()
 
     LocalFree(argvW);
 
-    return argv;
+    int len = WideCharToMultiByte(CP_UTF8, 0, wszGameArgs.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    std::string gameArgs = std::string(len - 1, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wszGameArgs.c_str(), -1, gameArgs.data(), len, nullptr, nullptr);
+
+    return {
+        argv,
+        gameArgs,
+    };
 }
 
-int Run(const std::vector<std::string>& arguments)
+int Run(const Arguments& arguments)
 {
     constexpr auto const VersionString = "SyringeEx " SYRINGEEX_VER_TEXT ", based on Syringe 0.7.2.0";
 
@@ -39,14 +96,14 @@ int Run(const std::vector<std::string>& arguments)
     Log::WriteLine(VersionString);
     Log::WriteLine("===============");
     Log::WriteLine();
-    Log::WriteLine("WinMain: arguments = \"%.*s\"", printable(arguments));
+    Log::WriteLine("WinMain: arguments = \"%.*s\"", printable(arguments.syringe_args));
 
     auto failure = "Could not load executable.";
     auto exit_code = ERROR_ERRORS_ENCOUNTERED;
 
     try
     {
-        auto const command = parse_command_line(arguments);
+        auto const command = parse_command_line(arguments.syringe_args);
 
         Log::WriteLine(
             "WinMain: Trying to load executable file \"%.*s\"...",
@@ -62,10 +119,10 @@ int Run(const std::vector<std::string>& arguments)
 
         Log::WriteLine(
             "WinMain: SyringeDebugger::Run(\"%.*s\");",
-            printable(command.game_arguments));
+            printable(arguments.game_args));
         Log::WriteLine();
 
-        Debugger.Run(command.game_arguments);
+        Debugger.Run(arguments.game_args);
         Log::WriteLine("WinMain: SyringeDebugger::Run finished.");
         Log::WriteLine("WinMain: Exiting on success.");
         return ERROR_SUCCESS;
@@ -84,7 +141,7 @@ int Run(const std::vector<std::string>& arguments)
     {
         MessageBoxA(
             nullptr, "Syringe cannot be run like that.\n\n"
-            "Usage:\nSyringe.exe <exe name> [-i=<injectedfile.dll> ...] [-- <arguments>]",
+                     "Usage:\nSyringe.exe <exe name> [-i=<injectedfile.dll> ...] [-- <arguments>]",
             VersionString, MB_OK | MB_ICONINFORMATION);
 
         Log::WriteLine(

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ syringe.exe game.exe
 
 ### Passing Arguments to the Target Executable
 
-Use `--args="..."` to provide arguments for the launched process:
+Use `--` as a delimiter to pass arguments to the launched process. All arguments after `--` will be forwarded directly to the target executable:
 
 ```
-syringe.exe game.exe --args="-CD. -SPAWN"
+syringe.exe game.exe -- -CD. -SPAWN
 ```
 
 ### DLL Injection Behavior

--- a/Support.h
+++ b/Support.h
@@ -32,7 +32,6 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
     {
         std::vector<std::string> syringe_arguments;
         std::string executable_name;
-        std::string game_arguments;
     };
 
     if (arguments.empty())
@@ -42,8 +41,6 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
 
     // First non-flag argument becomes executable name
     bool exe_found = false;
-
-    bool exe_arguments = false;
 
     for (const auto& arg : arguments)
     {
@@ -59,32 +56,16 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
             continue;
         }
 
-        if (arg == "--")
-        {
-            exe_arguments = true;
-            continue;
-        }
-
-        if (exe_arguments)
-        {
-            // game arguments
-            ret.game_arguments += " ";
-            ret.game_arguments += arg;
-        }
+        // Syringe arguments
+        if (arg.starts_with("-i=\"") && arg.ends_with('"'))
+            ret.syringe_arguments.push_back("-i=" + arg.substr(4, arg.length() - 5));
         else
-        {
-            // Syringe arguments
-            if (arg.starts_with("-i=\"") && arg.ends_with('"'))
-                ret.syringe_arguments.push_back("-i=" + arg.substr(4, arg.length() - 5));            
-            else 
-                ret.syringe_arguments.push_back(arg);
-        }
+            ret.syringe_arguments.push_back(arg);
     }
 
     if (!exe_found || ret.executable_name.empty())
         throw invalid_command_arguments{};
 
-    ret.game_arguments = ret.game_arguments.substr(1);
 
     return ret;
 }

--- a/Support.h
+++ b/Support.h
@@ -28,8 +28,6 @@ inline auto trim(std::string_view string) noexcept
 
 inline auto parse_command_line(const std::vector<std::string>& arguments)
 {
-    static constexpr std::string_view ARGS_FLAG = "--args=";
-
     struct argument_set
     {
         std::vector<std::string> syringe_arguments;
@@ -45,6 +43,8 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
     // First non-flag argument becomes executable name
     bool exe_found = false;
 
+    bool exe_arguments = false;
+    
     for (const auto& arg : arguments)
     {
         // executable name: first argument not starting with '-'
@@ -55,21 +55,29 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
             continue;
         }
 
-        // game arguments: --args="blob"
-        if (arg.starts_with(ARGS_FLAG))
+        if (arg == "--")
         {
-            // extract after --args=
-            std::string blob = arg.substr(ARGS_FLAG.size());
-            ret.game_arguments = blob;
+            exe_arguments = true;
             continue;
         }
 
-        // Syringe arguments
-        ret.syringe_arguments.push_back(arg);
+        if (exe_arguments)
+        {
+            // game arguments
+            ret.game_arguments += " ";
+            ret.game_arguments += arg;
+        }
+        else
+        {
+            // Syringe arguments
+            ret.syringe_arguments.push_back(arg);
+        }
     }
 
     if (!exe_found || ret.executable_name.empty())
         throw invalid_command_arguments{};
+
+    ret.game_arguments = ret.game_arguments.substr(1);
 
     return ret;
 }

--- a/Support.h
+++ b/Support.h
@@ -44,14 +44,18 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
     bool exe_found = false;
 
     bool exe_arguments = false;
-    
+
     for (const auto& arg : arguments)
     {
         // executable name: first argument not starting with '-'
         if (!exe_found && !arg.starts_with("-"))
         {
             exe_found = true;
-            ret.executable_name = arg;
+            if (arg.starts_with('"') && arg.ends_with('"'))
+                ret.executable_name = arg.substr(1, arg.length() - 2);
+            else
+                ret.executable_name = arg;
+
             continue;
         }
 
@@ -70,7 +74,10 @@ inline auto parse_command_line(const std::vector<std::string>& arguments)
         else
         {
             // Syringe arguments
-            ret.syringe_arguments.push_back(arg);
+            if (arg.starts_with("-i=\"") && arg.ends_with('"'))
+                ret.syringe_arguments.push_back("-i=" + arg.substr(4, arg.length() - 5));            
+            else 
+                ret.syringe_arguments.push_back(arg);
         }
     }
 


### PR DESCRIPTION
The reason for this change is to improve the command-line argument parsing method by adopting the standard `--` delimiter syntax commonly used in Unix/Linux systems.

## Why Change?

### Old Approach
```
Syringe.exe game.exe -i=mod.dll --args="-CD. -SPAWN"
```
- Used `--args=` flag to pass game arguments
- Required wrapping game arguments in quotes as a single string
- Less intuitive syntax and prone to confusion

### New Approach
```
Syringe.exe game.exe -i=mod.dll -- -CD. -SPAWN
```
- Uses `--` as delimiter, which is a standard convention in Unix/Linux
- All arguments after `--` are passed directly to the target program
- Clearer syntax that aligns with common command-line tool conventions

## Technical Details

In the `parse_command_line` function in `Support.h`:
1. When `--` is encountered, the `exe_arguments` flag is set to true
2. All subsequent arguments are appended to the `game_arguments` string
3. Finally, `substr(1)` removes the leading extra space

## Advantages
- Follows POSIX standard conventions (used by tools like `git`, `docker`, etc.)
- Arguments don't require additional quotes, reducing error potential
- Simpler code without special `--args=` flag handling
- Easier to understand and maintain

---

Where is issues?