### PR TITLE
Fix bootstrap DLL and hook injection under Wine, and select the resume mechanism per host

### DIFF
--- a/SyringeDebugger.cpp
+++ b/SyringeDebugger.cpp
@@ -70,6 +70,80 @@ bool SyringeDebugger::SetBP(void* address)
     return true;
 }
 
+size_t SyringeDebugger::DetermineOverwriteSize(void* addr, size_t minBytes)
+{
+    // Read a generous window and decode instructions one at a time until
+    // we've accumulated at least minBytes worth of complete instructions -
+    // never cutting an instruction in half, same principle RebuildInstructions
+    // already relies on elsewhere in this file.
+    constexpr size_t ReadWindow = 32;
+    BYTE buffer[ReadWindow] = {};
+    ReadMem(addr, buffer, ReadWindow);
+
+    ZydisDecoder decoder;
+    ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_COMPAT_32, ZYDIS_STACK_WIDTH_32);
+
+    size_t offset = 0;
+    while (offset < minBytes && offset < ReadWindow)
+    {
+        ZydisDecodedInstruction instruction;
+        ZydisDecodedOperand operands[ZYDIS_MAX_OPERAND_COUNT];
+
+        if (ZYAN_FAILED(ZydisDecoderDecodeFull(
+                &decoder, buffer + offset, ReadWindow - offset, &instruction, operands)))
+        {
+            // Undecodable bytes here: fall back to a plain minBytes overwrite
+            // rather than risk splitting an instruction in half.
+            return minBytes;
+        }
+
+        offset += instruction.length;
+    }
+
+    return offset;
+}
+
+bool SyringeDebugger::WriteRedirectJmp(void* resumeAddr, void* target)
+{
+    BYTE jmpBytes[5];
+    jmpBytes[0] = 0xE9;
+    auto const rel = RelativeOffset(
+        reinterpret_cast<BYTE*>(resumeAddr) + 5, target);
+    ApplyPatch(jmpBytes + 1, rel);
+
+    return PatchMem(resumeAddr, jmpBytes, sizeof(jmpBytes));
+}
+
+void SyringeDebugger::BuildEntryTrampoline()
+{
+    entryOverwriteSize = DetermineOverwriteSize(pcEntryPoint, 5);
+
+    std::vector<BYTE> original(entryOverwriteSize);
+    ReadMem(pcEntryPoint, original.data(), entryOverwriteSize);
+
+    // trampoline buffer: rebuilt original instructions + jmp back to
+    // pcEntryPoint+entryOverwriteSize to resume normal execution for real.
+    auto const trampolineSize = entryOverwriteSize * 3 + 5;
+    pEntryTrampoline = AllocMem(nullptr, trampolineSize);
+    entryContinueAddr = reinterpret_cast<BYTE*>(pcEntryPoint) + entryOverwriteSize;
+
+    auto rebuilt = RebuildInstructions(
+        original.data(), entryOverwriteSize,
+        reinterpret_cast<DWORD>(pcEntryPoint),
+        reinterpret_cast<DWORD>(pEntryTrampoline.get()));
+
+    std::vector<BYTE> code = rebuilt;
+    auto const jmpBackAt = pEntryTrampoline.get() + code.size();
+    BYTE jmpBack[5];
+    jmpBack[0] = 0xE9;
+    auto const rel = RelativeOffset(
+        reinterpret_cast<BYTE*>(jmpBackAt) + 5, entryContinueAddr);
+    ApplyPatch(jmpBack + 1, rel);
+    code.insert(code.end(), jmpBack, jmpBack + 5);
+
+    PatchMem(pEntryTrampoline.get(), code.data(), code.size());
+}
+
 DWORD __fastcall SyringeDebugger::RelativeOffset(void const* pFrom, void const* pTo)
 {
     auto const from = reinterpret_cast<DWORD>(pFrom);
@@ -326,6 +400,163 @@ std::vector<BYTE> SyringeDebugger::RebuildInstructions(
     return result;
 }
 
+void SyringeDebugger::CreateCodeHooks()
+{
+    if (bHooksCreated)
+    {
+        return;
+    }
+
+    Log::WriteLine(__FUNCTION__ ": Creating code hooks.");
+
+    // FS:[0x14] is a part of the Thread Information Block (TIB)
+    // structure and is designated as the "arbitrary user pointer".
+    // While Raymond Chen has mentioned that this field is "not safe"
+    // to use for arbitrary purposes, this appears to not be the case,
+    // judging by the article he cites as source (lol)
+
+    // https://devblogs.microsoft.com/oldnewthing/20190418-00/?p=102428
+    // https://web.archive.org/web/20250707201905/http://www.nynaeve.net/?p=98
+
+    #define POPFD_POPAD \
+        0x9D, /* POPFD */ \
+        /* start POPAD replica */ \
+        0x5F, /* POP EDI */ \
+        0x5E, /* POP ESI */ \
+        0x5D, /* POP EBP */ \
+        0x5B, /* POP EBX (temporary storage for modified ESP) */ \
+        0x8B, 0x44, 0x24, 0x0C, /* MOV EAX, [ESP + 0xC] (restore EAX which is last in PUSHAD order) */ \
+        0x89, 0x5C, 0x24, 0x0C, /* MOV [ESP + 0xC], EBX (place ESP last) */ \
+        0x5B, /* POP EBX */ \
+        0x5A, /* POP EDX */ \
+        0x59, /* POP ECX */ \
+        0x5C /* POP ESP (restore ESP last thus not corrupting the stack pointer before all POPs are done) */ \
+        /* end POPAD replica */
+
+    static BYTE const code_call[] =
+    {
+        0x60, 0x9C, // PUSHAD, PUSHFD
+        0x68, INIT, INIT, INIT, INIT, // PUSH HookAddress
+        0x54, // PUSH ESP (final REGISTERS* argument)
+        0xE8, INIT, INIT, INIT, INIT, // CALL ProcAddress
+        0x83, 0xC4, 0x08, // ADD ESP, 8
+        0x64, /* FS segment prefix */ 0xA3, 0x14, 0x00, 0x00, 0x00, // MOV fs:0x14, EAX
+        0x64, /* FS segment prefix */ 0x83, 0x3D, 0x14, 0x00, 0x00, 0x00, 0x00, // CMP DWORD PTR fs:0x14, 0
+        0x74, 0x18, // JE proceed
+
+        // jmp_to_address:
+        POPFD_POPAD,
+        0x64, /* FS segment prefix */ 0xFF, 0x25, 0x14, 0x00, 0x00, 0x00, // JMP DWORD PTR fs:0x14
+
+        // proceed:
+        POPFD_POPAD,
+        // here will be the overwritten bytes and jump back
+    };
+
+    // return 0 hooks are chained, so this structure may repeat
+
+    static BYTE const jmp_back[] = { 0xE9, INIT, INIT, INIT, INIT };
+    static BYTE const jmp[] = { 0xE9, INIT, INIT, INIT, INIT };
+
+    std::vector<BYTE> code;
+
+    for (auto& it : Breakpoints)
+    {
+        if (it.first == nullptr || it.first == pcEntryPoint)
+        {
+            continue;
+        }
+
+        auto const [count, overridden] = std::accumulate(
+            it.second.hooks.cbegin(), it.second.hooks.cend(),
+            std::make_pair(0u, 0u), [](auto acc, auto const& hook)
+            {
+                if (hook.proc_address) {
+                    if (acc.second < hook.num_overridden) {
+                        acc.second = hook.num_overridden;
+                    }
+                    acc.first++;
+                }
+                return acc; });
+
+        if (!count)
+        {
+            continue;
+        }
+
+        // read the overridden bytes from the target process
+        std::vector<BYTE> original_bytes(overridden);
+        ReadMem(it.first, original_bytes.data(), overridden);
+
+        // use a conservative upper bound for rebuilt instructions,
+        // since relative instruction re-encoding may change sizes
+        // (e.g. short branch -> near branch)
+        auto const max_rebuilt = overridden * 3;
+        auto const sz = count * sizeof(code_call) + sizeof(jmp_back) + max_rebuilt;
+
+        code.resize(sz);
+        auto p_code = code.data();
+
+        it.second.p_caller_code = AllocMem(nullptr, sz);
+        auto const base = it.second.p_caller_code.get();
+
+        // write caller code
+        for (auto const& hook : it.second.hooks)
+        {
+            if (hook.proc_address)
+            {
+                ApplyPatch(p_code, code_call);		 // code
+                ApplyPatch(p_code + 0x03, it.first); // PUSH HookAddress
+
+                auto const rel = RelativeOffset(
+                    base + (p_code - code.data() + 0x0D), hook.proc_address);
+                ApplyPatch(p_code + 0x09, rel); // CALL
+
+                p_code += sizeof(code_call);
+            }
+        }
+
+        // rebuild overridden bytes, adjusting relative addresses
+        if (overridden)
+        {
+            auto const originalAddr = reinterpret_cast<DWORD>(it.first);
+            auto const newAddr = reinterpret_cast<DWORD>(
+                base + (p_code - code.data()));
+
+            auto rebuilt = RebuildInstructions(
+                original_bytes.data(), overridden, originalAddr, newAddr);
+
+            std::memcpy(p_code, rebuilt.data(), rebuilt.size());
+            p_code += rebuilt.size();
+        }
+
+        // write the jump back
+        auto const rel = RelativeOffset(
+            base + (p_code - code.data() + 0x05),
+            static_cast<BYTE*>(it.first) + 0x05);
+        ApplyPatch(p_code, jmp_back);
+        ApplyPatch(p_code + 0x01, rel);
+        p_code += sizeof(jmp_back);
+
+        auto const actual_sz = static_cast<size_t>(p_code - code.data());
+        PatchMem(base, code.data(), actual_sz);
+
+        // patch original code
+        auto const p_original_code = static_cast<BYTE*>(it.first);
+
+        auto const rel2 = RelativeOffset(p_original_code + 5, base);
+        code.assign(std::max(overridden, sizeof(jmp)), NOP);
+        ApplyPatch(code.data(), jmp);
+        ApplyPatch(code.data() + 0x01, rel2);
+
+        PatchMem(p_original_code, code.data(), code.size());
+    }
+
+    Log::Flush();
+
+    bHooksCreated = true;
+}
+
 DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
 {
     auto const exceptCode = dbgEvent.u.Exception.ExceptionRecord.ExceptionCode;
@@ -358,8 +589,17 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
         // load DLLs and retrieve proc addresses
         if (!bDLLsLoaded)
         {
-            // restore
-            PatchMem(exceptAddr, &Breakpoints[exceptAddr].original_opcode, 1);
+            bool const isFirstVisit = (loop_LoadLibrary == v_AllHooks.end());
+
+            if (isFirstVisit && exceptAddr == pcEntryPoint)
+            {
+                // restore the real original first byte (saved by SetBP)
+                // before reading pcEntryPoint's bytes for real, then build
+                // the trampoline that will let us resume real execution
+                // there later without losing any original instructions.
+                PatchMem(exceptAddr, &Breakpoints[exceptAddr].original_opcode, 1);
+                BuildEntryTrampoline();
+            }
 
             if (loop_LoadLibrary == v_AllHooks.end())
             {
@@ -381,13 +621,18 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                 ++loop_LoadLibrary;
             }
 
+            // The CPU resumes at exceptAddr+1 per standard INT3 semantics
+            // (auto-advanced past the 1-byte breakpoint opcode). We redirect
+            // by writing a real JMP there instead of touching thread context.
+            void* resumeAddr = reinterpret_cast<BYTE*>(exceptAddr) + 1;
+
             if (loop_LoadLibrary != v_AllHooks.end())
             {
                 auto const& hook = *loop_LoadLibrary;
                 PatchMem(&GetData()->LibName, hook->lib, MaxNameLength);
                 PatchMem(&GetData()->ProcName, hook->proc, MaxNameLength);
 
-                context.Eip = reinterpret_cast<DWORD>(&GetData()->LoadLibraryFunc);
+                WriteRedirectJmp(resumeAddr, &GetData()->LoadLibraryFunc);
             }
             else
             {
@@ -402,19 +647,17 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                     PatchMem(&GetData()->LibName, entry.lib, MaxNameLength);
                     PatchMem(&GetData()->ProcName, entry.symbol, MaxNameLength);
 
-                    context.Eip = reinterpret_cast<DWORD>(&GetData()->LoadLibraryFunc);
+                    WriteRedirectJmp(resumeAddr, &GetData()->LoadLibraryFunc);
                 }
                 else
                 {
                     bFeaturesSet = true;
-                    context.Eip = reinterpret_cast<DWORD>(pcEntryPoint);
+                    // No feature flags AND no more DLLs to load in one shot:
+                    // all hooks can be installed right now.
+                    CreateCodeHooks();
+                    WriteRedirectJmp(resumeAddr, pEntryTrampoline.get());
                 }
             }
-
-            // single step mode
-            context.EFlags |= 0x100;
-            context.ContextFlags = CONTEXT_CONTROL;
-            SetThreadContext(currentThread, &context);
 
             threadInfo.lastBP = exceptAddr;
 
@@ -424,8 +667,13 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
         // set feature flags in loaded DLLs
         if (!bFeaturesSet)
         {
-            // restore
-            PatchMem(exceptAddr, &Breakpoints[exceptAddr].original_opcode, 1);
+            // No restore here: exceptAddr is the stub's own embedded INT3
+            // (in pAlloc), never registered via SetBP, so Breakpoints[exceptAddr]
+            // is a meaningless default-constructed entry. Restoring from it
+            // would zero out the stub's own breakpoint marker, corrupting
+            // every subsequent re-execution of the stub. It must stay intact
+            // across all iterations since we always redirect away from it via
+            // WriteRedirectJmp rather than ever falling through past it.
 
             // read the resolved address of the feature flag in the target process
             void* flagAddr = nullptr;
@@ -448,26 +696,24 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
 
             ++loop_FeatureFlags;
 
+            void* resumeAddr = reinterpret_cast<BYTE*>(exceptAddr) + 1;
+
             if (loop_FeatureFlags != v_FeatureFlags.end())
             {
                 auto const& entry = *loop_FeatureFlags;
                 PatchMem(&GetData()->LibName, entry.lib, MaxNameLength);
                 PatchMem(&GetData()->ProcName, entry.symbol, MaxNameLength);
 
-                context.Eip = reinterpret_cast<DWORD>(&GetData()->LoadLibraryFunc);
+                WriteRedirectJmp(resumeAddr, &GetData()->LoadLibraryFunc);
             }
             else
             {
                 Log::WriteLine(__FUNCTION__ ": Finished setting feature flags.");
                 bFeaturesSet = true;
 
-                context.Eip = reinterpret_cast<DWORD>(pcEntryPoint);
+                CreateCodeHooks();
+                WriteRedirectJmp(resumeAddr, pEntryTrampoline.get());
             }
-
-            // single step mode
-            context.EFlags |= 0x100;
-            context.ContextFlags = CONTEXT_CONTROL;
-            SetThreadContext(currentThread, &context);
 
             threadInfo.lastBP = exceptAddr;
 
@@ -820,7 +1066,9 @@ void SyringeDebugger::Run(std::string_view const arguments)
         0x5A,								// pop edx
         0x59,								// pop ecx
         0x58,								// pop eax
-        INT3, NOP							// int3 and some padding
+        INT3, NOP, NOP, NOP, NOP, NOP		// int3 and enough padding for a
+                                            // WriteRedirectJmp (5 bytes) to
+                                            // land safely right after it
     };
 
     std::array<BYTE, AllocDataSize> data;
@@ -858,7 +1106,6 @@ void SyringeDebugger::Run(std::string_view const arguments)
         WaitForDebugEvent(&dbgEvent, INFINITE);
 
         DWORD continueStatus = DBG_CONTINUE;
-        bool wasSingleStep = false;
 
         switch (dbgEvent.dwDebugEventCode)
         {
@@ -882,7 +1129,6 @@ void SyringeDebugger::Run(std::string_view const arguments)
 
         case EXCEPTION_DEBUG_EVENT:
             continueStatus = HandleException(dbgEvent);
-            wasSingleStep = (dbgEvent.u.Exception.ExceptionRecord.ExceptionCode == EXCEPTION_SINGLE_STEP);
             break;
 
         case LOAD_DLL_DEBUG_EVENT:
@@ -907,7 +1153,12 @@ void SyringeDebugger::Run(std::string_view const arguments)
 
         ContinueDebugEvent(dbgEvent.dwProcessId, dbgEvent.dwThreadId, continueStatus);
 
-        if (bDetachWhenDone && bHooksCreated && wasSingleStep)
+        // Previously gated on wasSingleStep, since hook creation used to be
+        // detected via a single-step trap after redirecting back to
+        // pcEntryPoint. That path no longer single-steps at all - CreateCodeHooks
+        // now runs synchronously and sets bHooksCreated directly, so checking
+        // it alone is sufficient and correct here.
+        if (bDetachWhenDone && bHooksCreated)
         {
             Log::WriteLine(__FUNCTION__ ": Hooks placed, detaching debugger.");
 

--- a/SyringeDebugger.cpp
+++ b/SyringeDebugger.cpp
@@ -17,6 +17,51 @@
 
 using namespace std;
 
+namespace {
+enum class WineFlavor { NativeWindows, CrossOver, OtherWine };
+
+bool RegistryKeyExists(HKEY root, char const* subKey)
+{
+    HKEY key;
+    if (RegOpenKeyExA(root, subKey, 0, KEY_READ, &key) == ERROR_SUCCESS)
+    {
+        RegCloseKey(key);
+        return true;
+    }
+    return false;
+}
+
+// Wine exports wine_get_version/wine_get_build_id from ntdll; native Windows does not.
+// A mainline Wine can be told to hide those exports (HideWineExports, an anti-detection
+// setting), so also accept the HKCU\Software\Wine configuration key, which such setups
+// still carry and native Windows never has.
+bool IsWineHost()
+{
+    HMODULE ntdll = GetModuleHandleA("ntdll.dll");
+    if (ntdll && (GetProcAddress(ntdll, "wine_get_version") || GetProcAddress(ntdll, "wine_get_build_id")))
+        return true;
+    return RegistryKeyExists(HKEY_CURRENT_USER, "Software\\Wine");
+}
+
+// CrossOver's Wine reports a plain "wine-11.0-..." build id, indistinguishable from
+// mainline/Whisky Wine by version, so it is identified instead by the registry keys
+// CrossOver writes into its bottles and plain Wine lacks: the per-bottle
+// HKCU\Software\CrossOver settings key, or the HKLM\Software\CodeWeavers\CrossOver
+// product registration. Either one is sufficient.
+bool IsCrossOverHost()
+{
+    return RegistryKeyExists(HKEY_CURRENT_USER, "Software\\CrossOver")
+        || RegistryKeyExists(HKEY_LOCAL_MACHINE, "Software\\CodeWeavers\\CrossOver");
+}
+
+WineFlavor DetectWineFlavor()
+{
+    if (!IsWineHost()) return WineFlavor::NativeWindows;
+    if (IsCrossOverHost()) return WineFlavor::CrossOver;
+    return WineFlavor::OtherWine;
+}
+} // namespace
+
 void SyringeDebugger::DebugProcess(std::string_view const arguments)
 {
     STARTUPINFO startupInfo{ sizeof(startupInfo) };
@@ -112,6 +157,49 @@ bool SyringeDebugger::WriteRedirectJmp(void* resumeAddr, void* target)
     ApplyPatch(jmpBytes + 1, rel);
 
     return PatchMem(resumeAddr, jmpBytes, sizeof(jmpBytes));
+}
+
+void SyringeDebugger::RedirectExecution(HANDLE thread, void* resumeAddr, void* target)
+{
+    if (bResumeViaThreadContext)
+    {
+        // Native Windows + CrossOver both honor an Eip redirect on debug-event resume,
+        // and CrossOver additionally faults on a written-JMP trampoline, so we write no
+        // JMP here. `target` is a stub start or a pcEntryPoint whose INT3 the caller has
+        // already restored, so setting Eip is sufficient; `resumeAddr` is unused.
+        CONTEXT ctx;
+        ctx.ContextFlags = CONTEXT_CONTROL;
+        GetThreadContext(thread, &ctx);
+        ctx.Eip = reinterpret_cast<DWORD>(target);
+        ctx.ContextFlags = CONTEXT_CONTROL;
+        SetThreadContext(thread, &ctx);
+    }
+    else
+    {
+        // Mainline/Whisky Wine: Eip redirects to distant/allocated targets are silently
+        // ignored, but a real E9 JMP patched at the CPU's actual resume point (bpAddr+1)
+        // is executed. Byte-identical to the JMP-only build.
+        WriteRedirectJmp(resumeAddr, target);
+    }
+}
+
+void SyringeDebugger::ResumeAtEntryPoint(HANDLE thread, void* resumeAddr)
+{
+    void* entryTarget;
+    if (bResumeViaThreadContext)
+    {
+        // Context path: resume at the pristine entry point. Clearing its INT3 is
+        // idempotent - the first entry-breakpoint visit already restored the byte.
+        PatchMem(pcEntryPoint, &Breakpoints[pcEntryPoint].original_opcode, 1);
+        entryTarget = pcEntryPoint;
+    }
+    else
+    {
+        // JMP path: resume through the trampoline, which the first-visit redirect
+        // made mandatory by clobbering entry+1..+5.
+        entryTarget = pEntryTrampoline.get();
+    }
+    RedirectExecution(thread, resumeAddr, entryTarget);
 }
 
 void SyringeDebugger::BuildEntryTrampoline()
@@ -598,7 +686,10 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                 // the trampoline that will let us resume real execution
                 // there later without losing any original instructions.
                 PatchMem(exceptAddr, &Breakpoints[exceptAddr].original_opcode, 1);
-                BuildEntryTrampoline();
+                // The trampoline is only a JMP-path jump target; the context path resumes at
+                // a pristine pcEntryPoint and never clobbers entry+1..+5, so skip building it.
+                if (!bResumeViaThreadContext)
+                    BuildEntryTrampoline();
             }
 
             if (loop_LoadLibrary == v_AllHooks.end())
@@ -632,7 +723,7 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                 PatchMem(&GetData()->LibName, hook->lib, MaxNameLength);
                 PatchMem(&GetData()->ProcName, hook->proc, MaxNameLength);
 
-                WriteRedirectJmp(resumeAddr, &GetData()->LoadLibraryFunc);
+                RedirectExecution(currentThread, resumeAddr, &GetData()->LoadLibraryFunc);
             }
             else
             {
@@ -647,7 +738,7 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                     PatchMem(&GetData()->LibName, entry.lib, MaxNameLength);
                     PatchMem(&GetData()->ProcName, entry.symbol, MaxNameLength);
 
-                    WriteRedirectJmp(resumeAddr, &GetData()->LoadLibraryFunc);
+                    RedirectExecution(currentThread, resumeAddr, &GetData()->LoadLibraryFunc);
                 }
                 else
                 {
@@ -655,7 +746,7 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                     // No feature flags AND no more DLLs to load in one shot:
                     // all hooks can be installed right now.
                     CreateCodeHooks();
-                    WriteRedirectJmp(resumeAddr, pEntryTrampoline.get());
+                    ResumeAtEntryPoint(currentThread, resumeAddr);
                 }
             }
 
@@ -704,7 +795,7 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                 PatchMem(&GetData()->LibName, entry.lib, MaxNameLength);
                 PatchMem(&GetData()->ProcName, entry.symbol, MaxNameLength);
 
-                WriteRedirectJmp(resumeAddr, &GetData()->LoadLibraryFunc);
+                RedirectExecution(currentThread, resumeAddr, &GetData()->LoadLibraryFunc);
             }
             else
             {
@@ -712,7 +803,7 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                 bFeaturesSet = true;
 
                 CreateCodeHooks();
-                WriteRedirectJmp(resumeAddr, pEntryTrampoline.get());
+                ResumeAtEntryPoint(currentThread, resumeAddr);
             }
 
             threadInfo.lastBP = exceptAddr;
@@ -1042,6 +1133,17 @@ void SyringeDebugger::Run(std::string_view const arguments)
         __FUNCTION__ ": Running process to debug. cmd = \"%s %.*s\"",
         exe.c_str(), printable(arguments));
     DebugProcess(arguments);
+
+    // Choose the bootstrap resume mechanism once, based on the host: SetThreadContext on
+    // native Windows and CrossOver (both honor an Eip change; CrossOver's x86->ARM
+    // translator additionally faults on the JMP trampoline), JMP-redirect on mainline/Whisky
+    // Wine (which silently ignores Eip redirects to distant, freshly-allocated targets).
+    WineFlavor const flavor = DetectWineFlavor();
+    bResumeViaThreadContext = (flavor != WineFlavor::OtherWine);
+    Log::WriteLine(__FUNCTION__ ": Host = %s, resume mechanism = %s",
+        flavor == WineFlavor::NativeWindows ? "native Windows"
+        : flavor == WineFlavor::CrossOver ? "Wine (CrossOver)" : "Wine (mainline)",
+        bResumeViaThreadContext ? "SetThreadContext" : "JMP-redirect");
 
     Log::WriteLine(__FUNCTION__ ": Allocating 0x%u bytes...", AllocDataSize);
     pAlloc = AllocMem(nullptr, AllocDataSize);

--- a/SyringeDebugger.h
+++ b/SyringeDebugger.h
@@ -89,6 +89,29 @@ public:
     bool SetBP(void* address);
     void RemoveBP(LPVOID address, bool restoreOpcode);
 
+    // Wine-safe bootstrap redirection: SetThreadContext's Eip field is not
+    // reliably honored by Wine's wow64 debug-event resume path when jumping
+    // to a distant, dynamically-allocated address (confirmed empirically -
+    // the thread just continues from wherever it actually was, silently
+    // ignoring the requested Eip, even though GetThreadContext falsely
+    // confirms the change). WriteProcessMemory-based code patching, by
+    // contrast, is reliable. These helpers redirect execution by writing a
+    // real JMP instruction at the actual CPU resume address (bpAddr+1, per
+    // standard INT3 semantics) instead of mutating thread context.
+    size_t DetermineOverwriteSize(void* addr, size_t minBytes);
+    bool WriteRedirectJmp(void* resumeAddr, void* target);
+    void BuildEntryTrampoline();
+
+    // Installs all real, ongoing hooks (writing JMP instructions at every
+    // registered hook site throughout the target). Originally only ever
+    // triggered by redirecting back to pcEntryPoint and waiting for a fresh
+    // breakpoint exception to fire there again - a mechanism that depends on
+    // Wine correctly honoring a SetThreadContext-based Eip change, which it
+    // does not. Called directly instead, the moment DLL loading and feature
+    // flag resolution finish, since the debugger already has full control at
+    // that point and does not need to wait for anything further.
+    void CreateCodeHooks();
+
     // memory
     VirtualMemoryHandle AllocMem(void* address, size_t size);
     bool PatchMem(void* address, void const* buffer, DWORD size);
@@ -197,6 +220,11 @@ private:
 
     bool bDLLsLoaded{ false };
     bool bHooksCreated{ false };
+
+    // Wine-safe bootstrap redirection state (see WriteRedirectJmp).
+    VirtualMemoryHandle pEntryTrampoline;
+    void* entryContinueAddr{ nullptr };
+    size_t entryOverwriteSize{ 0 };
 
     bool bAVLogged{ false };
 

--- a/SyringeDebugger.h
+++ b/SyringeDebugger.h
@@ -100,6 +100,14 @@ public:
     // standard INT3 semantics) instead of mutating thread context.
     size_t DetermineOverwriteSize(void* addr, size_t minBytes);
     bool WriteRedirectJmp(void* resumeAddr, void* target);
+    // Redirect the target thread's execution to `target`. On native Windows and
+    // CrossOver this sets Eip (both honor it, and CrossOver's x86->ARM translator
+    // faults on a written-JMP trampoline); on mainline/Whisky Wine it writes a JMP
+    // at `resumeAddr` (Eip redirects to distant targets are silently ignored there).
+    void RedirectExecution(HANDLE thread, void* resumeAddr, void* target);
+    // Resume the target at its entry point once bootstrap is done: on the context path
+    // at the pristine pcEntryPoint, on the JMP path through the entry trampoline.
+    void ResumeAtEntryPoint(HANDLE thread, void* resumeAddr);
     void BuildEntryTrampoline();
 
     // Installs all real, ongoing hooks (writing JMP instructions at every
@@ -225,6 +233,12 @@ private:
     VirtualMemoryHandle pEntryTrampoline;
     void* entryContinueAddr{ nullptr };
     size_t entryOverwriteSize{ 0 };
+
+    // Resume mechanism, chosen once in Run(): true on native Windows AND CrossOver
+    // (SetThreadContext Eip is honored; a written-JMP trampoline faults under
+    // CrossOver's x86->ARM translator). false on mainline/Whisky Wine (Eip redirects
+    // to distant targets are silently ignored; the JMP trampoline works).
+    bool bResumeViaThreadContext{ false };
 
     bool bAVLogged{ false };
 


### PR DESCRIPTION
# Fix bootstrap DLL and hook injection under Wine, and select the resume mechanism per host

## Problem

When Syringe runs under Wine, including Wine-based setups on macOS, Linux, and Proton, DLL injection and hook installation can silently fail.

The debugger loop continues running and the log may report the expected number of hooks, but the target process actually runs without any of them installed.

In CnCNet's Yuri's Revenge setup using Ares, Phobos, and CnCNet-Spawner, this causes the game to exit before `spawn.ini` is read.

## Root cause

Syringe previously redirected execution by modifying the debuggee thread's `Eip` through `SetThreadContext`.

Wine's WoW64 debug-event resume path does not reliably honor these `Eip` changes when redirecting execution to a distant, dynamically allocated address, such as the `LoadLibrary` bootstrap stub in `pAlloc`.

This failure is particularly misleading:

* `SetThreadContext` reports success.
* A subsequent `GetThreadContext` call reports the requested `Eip`.
* The thread nevertheless resumes from its original execution location.
* DLL loading, feature resolution, and hook installation therefore silently do not occur.

This behavior was reproduced independently using a minimal target executable and debugger outside this codebase. In that test, redirects performed through `WriteProcessMemory` were honored, while redirects performed through `SetThreadContext(Eip = ...)` were not.

## Fix

Execution is redirected by writing an actual relative `JMP` instruction at the CPU's real resume address, rather than relying on a thread-context mutation.

For an `INT3` breakpoint, the CPU resumes at `breakpointAddress + 1`, so the redirect is written there using `WriteProcessMemory`.

The implementation adds the following:

### `WriteRedirectJmp`

Writes a five-byte relative `JMP` at the debuggee's resume address, redirecting execution to the required bootstrap or continuation code.

### `DetermineOverwriteSize`

Decodes complete instructions until enough bytes are available for a safe five-byte jump, avoiding partial instruction overwrites.

### `BuildEntryTrampoline`

Creates a trampoline for returning to the executable entry point.

Because the entry point may contain instructions larger than the required jump, the trampoline:

1. determines how many complete instructions must be overwritten;
2. copies and rebuilds those instructions using the existing Zydis-based `RebuildInstructions` logic; and
3. jumps back to the first untouched instruction at the original entry point.

### `CreateCodeHooks`

The existing hook-generation and installation logic has been extracted into a dedicated method.

Hook creation now runs directly after DLL loading and feature-flag resolution complete. Syringe no longer redirects execution back to `pcEntryPoint` and waits for another breakpoint before creating the hooks, since that flow depended on the same unreliable `SetThreadContext` redirection.

## Resume mechanism selection per host

The written-`JMP` redirect is required on mainline Wine, but it is not correct everywhere.

Under CrossOver on Apple Silicon, the x86-to-ARM translator faults when the freshly written entry trampoline is executed, raising an access violation at the entry point before the game starts. CrossOver, unlike mainline Wine, does honor a `SetThreadContext` `Eip` redirect — the original mechanism works there.

The two resume strategies are therefore complementary, so Syringe now detects the host once at startup and chooses accordingly:

* **Native Windows** and **CrossOver** resume through `SetThreadContext`. On these hosts the entry trampoline is never built and the entry point is resumed unmodified.
* **Mainline Wine** (including Whisky and other plain-Wine setups on macOS/Linux/Proton) resumes through the written-`JMP` trampoline described above.

This only changes the resume primitive per host; the surrounding bootstrap flow (synchronous hook creation, no single-stepping) is the same on both paths.

Detection uses registry and export signals rather than the Wine version string, which is not usable here — CrossOver reports a plain `wine-11.0-...` build indistinguishable from mainline Wine:

* **Wine vs. native Windows** — the presence of Wine's `ntdll` exports (`wine_get_version` / `wine_get_build_id`), with the `HKCU\Software\Wine` configuration key as a fallback for Wine builds configured to hide those exports. Native Windows has neither.
* **CrossOver vs. mainline Wine** — the registry keys CrossOver writes into its bottles, `HKCU\Software\CrossOver` or `HKLM\Software\CodeWeavers\CrossOver`; either is sufficient. Plain Wine has neither.

A single helper, `RedirectExecution`, encapsulates the branch: it sets `Eip` on the context path and writes a `JMP` on the trampoline path. All bootstrap and continuation redirects go through it, so the mainline-Wine path remains byte-for-byte the written-`JMP` behavior.

## Additional corrections

The bootstrap stub's embedded `INT3` is no longer restored during the feature-flag loop.

That breakpoint was created directly inside the allocated bootstrap code and was never registered through `SetBP`. Attempting to restore it through the breakpoint map therefore used an invalid default entry and corrupted the bootstrap stub during subsequent iterations.

The `--detach` completion condition now checks `bHooksCreated` directly.

Previously, detachment also required a single-step exception because hook creation was detected after redirecting execution back to the entry point. Hook creation now happens synchronously, so that single-step event no longer occurs and is no longer required.

## Platform impact

On native Windows the resume primitive is `SetThreadContext`, exactly as stock Syringe used, and the entry trampoline is never built. The surrounding bootstrap follows this PR's synchronous hook-creation flow, shared with the Wine path. The `WriteProcessMemory`-based `JMP` redirect is used only on mainline Wine, and it relies on ordinary process-memory patching and relative jumps that are also valid on Windows.

## Testing

Tested end-to-end on macOS using Red Alert 2 / Yuri's Revenge with Ares, Phobos, CnCNet-Spawner, and approximately 2,750 installed hooks, on both host types:

* **Mainline Wine** — injection and hook installation complete; the game launches directly into a running match instead of exiting before `spawn.ini` is read. This is the case the written-`JMP` redirect fixes.
* **CrossOver on Apple Silicon** — with per-host selection, the bootstrap resumes through `SetThreadContext`, feature-flag resolution and all hooks install, and the earlier entry-point access violation no longer occurs.

Native Windows has not been retested on hardware, but its resume path is unchanged from stock Syringe (`SetThreadContext`, no trampoline), and the memory-patching mechanism used on the Wine path is the same one Syringe already uses elsewhere.
