### PR TITLE
Include DLL names in instruction rebuild warnings

### DIFF
--- a/SyringeDebugger.cpp
+++ b/SyringeDebugger.cpp
@@ -110,10 +110,18 @@ static void ResolveRelativeOperands(
 }
 
 std::vector<BYTE> SyringeDebugger::RebuildInstructions(
-    BYTE const* bytes, size_t size, DWORD originalAddr, DWORD newAddr)
+    BYTE const* bytes, size_t size, DWORD originalAddr, DWORD newAddr,
+    std::string_view const hookLibraries)
 {
     ZydisDecoder decoder;
     ZydisDecoderInit(&decoder, ZYDIS_MACHINE_MODE_LONG_COMPAT_32, ZYDIS_STACK_WIDTH_32);
+
+    std::string hookContext;
+    if (!hookLibraries.empty())
+    {
+        hookContext = " in DLL(s): ";
+        hookContext += hookLibraries;
+    }
 
     // --- Pass 1: decode all instructions and classify relative branches ---
 
@@ -147,9 +155,9 @@ std::vector<BYTE> SyringeDebugger::RebuildInstructions(
                 Log::WriteLine(
                     __FUNCTION__ ": Failed to decode instruction at 0x%08X, "
                     "copying remaining %u bytes verbatim. This could mean "
-                    "there is a faulty return 0 hook at 0x%08X.",
+                    "there is a faulty return 0 hook at 0x%08X%s.",
                     static_cast<DWORD>(srcAddr), static_cast<unsigned>(size - offset),
-                    originalAddr);
+                    originalAddr, hookContext.c_str());
 
                 tailOffset = offset;
                 break;
@@ -205,10 +213,10 @@ std::vector<BYTE> SyringeDebugger::RebuildInstructions(
                                     Log::WriteLine(
                                         __FUNCTION__ ": Relative instruction "
                                         "at 0x%08X has an intra-prologue target "
-                                        "but no near encoding. Hook at 0x%08X "
+                                        "but no near encoding. Hook at 0x%08X%s "
                                         "may not work correctly.",
-                                        static_cast<DWORD>(srcAddr),
-                                        originalAddr);
+                                        static_cast<DWORD>(srcAddr), originalAddr,
+                                        hookContext.c_str());
                                 }
                             }
                         }
@@ -555,6 +563,27 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                         continue;
                     }
 
+                    std::set<std::string_view> rebuildLibraries;
+                    for (auto const& hook : it.second.hooks)
+                    {
+                        if (hook.proc_address && hook.num_overridden == overridden)
+                        {
+                            rebuildLibraries.emplace(hook.lib);
+                        }
+                    }
+
+                    std::string rebuildLibraryNames;
+                    for (auto const library : rebuildLibraries)
+                    {
+                        if (!rebuildLibraryNames.empty())
+                        {
+                            rebuildLibraryNames += ", ";
+                        }
+                        rebuildLibraryNames += '"';
+                        rebuildLibraryNames += library;
+                        rebuildLibraryNames += '"';
+                    }
+
                     // read the overridden bytes from the target process
                     std::vector<BYTE> original_bytes(overridden);
                     ReadMem(it.first, original_bytes.data(), overridden);
@@ -595,7 +624,8 @@ DWORD SyringeDebugger::HandleException(DEBUG_EVENT const& dbgEvent)
                             base + (p_code - code.data()));
 
                         auto rebuilt = RebuildInstructions(
-                            original_bytes.data(), overridden, originalAddr, newAddr);
+                            original_bytes.data(), overridden, originalAddr, newAddr,
+                            rebuildLibraryNames);
 
                         std::memcpy(p_code, rebuilt.data(), rebuilt.size());
                         p_code += rebuilt.size();

--- a/SyringeDebugger.h
+++ b/SyringeDebugger.h
@@ -107,7 +107,9 @@ private:
 #ifdef SYRINGE_TESTING
 public:
 #endif
-    static std::vector<BYTE> RebuildInstructions(BYTE const* bytes, size_t size, DWORD originalAddr, DWORD newAddr);
+    static std::vector<BYTE> RebuildInstructions(
+        BYTE const* bytes, size_t size, DWORD originalAddr, DWORD newAddr,
+        std::string_view hookLibraries = {});
 #ifdef SYRINGE_TESTING
 private:
 #endif


### PR DESCRIPTION
## Summary

- Include the names of hook DLLs in `RebuildInstructions` warnings.
- Collect and deduplicate DLL names for hooks that override the same target address.
- Preserve the existing warning text when no DLL context is available.

## Motivation

Instruction rebuilding failures previously reported only the hook address, making it difficult to identify which extension supplied the problematic hook. The additional DLL context makes these diagnostics actionable and simplifies troubleshooting faulty hooks.
